### PR TITLE
Enhance Pre-commit Hook to Support Staged Diff-Based Commit Messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +526,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spinoff",
+ "strip-ansi-escapes",
  "tokio",
 ]
 
@@ -920,6 +927,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1133,27 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 async-trait = "0.1.83"
 spinoff = { version = "0.8.0", features = ["dots"] }
+strip-ansi-escapes = "0.1"
 
 [profile.release]
 lto = true

--- a/src/provider/phind.rs
+++ b/src/provider/phind.rs
@@ -57,12 +57,12 @@ impl PhindProvider {
         // Prioritize the diff content for the summary prompt if available
         let user_input = if !diff_content.is_empty() {
             format!(
-                "Please analyze the following staged changes and provide a summary.\n\nDiff Content:\n{}",
+                "Please analyze the following staged changes and provide a short, concise title and a detailed summary.\n\nDiff Content:\n{}",
                 diff_content
             )
         } else {
             format!(
-                "Please analyze this git commit and provide a summary.\n\nCommit Message:\n{}",
+                "Please analyze this git commit and provide a short, concise title and a detailed summary.\n\nCommit Message:\n{}",
                 commit_message
             )
         };

--- a/src/provider/phind.rs
+++ b/src/provider/phind.rs
@@ -54,10 +54,18 @@ impl PhindProvider {
         commit_message: &str,
         diff_content: &str,
     ) -> Result<PhindRequest, Box<dyn std::error::Error>> {
-        let user_input = format!(
-            "Please analyze this git commit and provide a summary.\n\nCommit Message:\n{}\n\nDiff Content:\n{}",
-            commit_message, diff_content
-        );
+        // Prioritize the diff content for the summary prompt if available
+        let user_input = if !diff_content.is_empty() {
+            format!(
+                "Please analyze the following staged changes and provide a summary.\n\nDiff Content:\n{}",
+                diff_content
+            )
+        } else {
+            format!(
+                "Please analyze this git commit and provide a summary.\n\nCommit Message:\n{}",
+                commit_message
+            )
+        };
 
         Ok(PhindRequest {
             additional_extension_context: String::new(),


### PR DESCRIPTION
This pull request updates the pre-commit hook to support commit message generation based on staged diffs rather than individual commits. This enhancement allows for more dynamic and relevant commit messages by summarizing only the changes staged for the next commit.