### PR TITLE
refactor: use indoc for multiline strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +522,7 @@ version = "1.4.0"
 dependencies = [
  "async-trait",
  "clap",
+ "indoc",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1.0", features = ["full"] }
 async-trait = "0.1.83"
 spinoff = { version = "0.8.0", features = ["dots"] }
 thiserror = "1.0"
+indoc = "2.0.5"
 
 [profile.release]
 lto = true

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -1,5 +1,6 @@
 use crate::config::cli::ProviderType;
 use crate::error::LumenError;
+use indoc::indoc;
 use serde::{Deserialize, Deserializer};
 use serde_json::from_reader;
 use std::collections::HashMap;
@@ -51,7 +52,8 @@ where
 }
 
 fn default_commit_types() -> String {
-    r#"{
+    indoc! {r#"
+    {
         "docs": "Documentation only changes",
         "style": "Changes that do not affect the meaning of the code",
         "refactor": "A code change that neither fixes a bug nor adds a feature",
@@ -63,7 +65,8 @@ fn default_commit_types() -> String {
         "revert": "Reverts a previous commit",
         "feat": "A new feature",
         "fix": "A bug fix"
-    }"#
+    }
+    "#}
     .to_string()
 }
 

--- a/src/git_entity/mod.rs
+++ b/src/git_entity/mod.rs
@@ -1,5 +1,6 @@
 use git_commit::GitCommit;
 use git_diff::GitDiff;
+use indoc::formatdoc;
 
 pub mod git_commit;
 pub mod git_diff;
@@ -13,22 +14,22 @@ pub enum GitEntity {
 impl GitEntity {
     pub fn format_static_details(&self) -> String {
         match self {
-            GitEntity::Commit(commit) => format!(
-                "{}\n`commit {}` | {} <{}> | {}\n\n{}\n-----\n",
-                "# Entity: Commit",
-                commit.full_hash,
-                commit.author_name,
-                commit.author_email,
-                commit.date,
-                commit.message,
-            ),
-            GitEntity::Diff(diff) => {
-                format!(
-                    "{}{}\n",
-                    "# Entity: Diff",
-                    if diff.staged { " (staged)" } else { "" }
-                )
-            }
+            GitEntity::Commit(commit) => formatdoc! {"
+                # Entity: Commit
+                `commit {hash}` | {author} <{email}> | {date}
+
+                {message}
+                -----",
+                hash = commit.full_hash,
+                author = commit.author_name,
+                email = commit.author_email,
+                date = commit.date,
+                message = commit.message,
+            },
+            GitEntity::Diff(diff) => formatdoc! {"
+                # Entity: Diff{staged}",
+                staged = if diff.staged { " (staged)" } else { "" }
+            },
         }
     }
 }


### PR DESCRIPTION
This PR refactors the code to replace standard multiline strings with the `indoc` crate, which helps maintain readability and also trims the indentation from the real string (doing that can actually reduce LLM token usage by a bit)