### PR TITLE
fix: correct typo in `LumenError`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,5 +32,5 @@ pub enum LumenError {
     CommandError(String),
 
     #[error(transparent)]
-    ProvderError(#[from] ProviderError),
+    ProviderError(#[from] ProviderError),
 }


### PR DESCRIPTION
Fixes a typo in `LumenError`