### PR TITLE
feat: add command version option to CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod provider;
 #[derive(Parser)]
 #[command(name = "lumen")]
 #[command(about = "AI-powered CLI tool for git commit summaries", long_about = None)]
+#[command(version)]
 struct Cli {
     #[arg(
         value_enum,


### PR DESCRIPTION
This pull request adds a `--version` (or `-V`) option to the CLI, allowing users to check the current version of the application.