### PR TITLE
STDIN support for `explain` command implemented

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings" defaultProject="true" />
+</project>

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ lumen explain HEAD                    # Latest commit
 lumen explain abc123f                 # Specific commit
 lumen explain HEAD~3..HEAD            # Last 3 commits
 lumen explain main..feature/A         # Branch comparison
+echo "abc123f" | lumen explain -      # Specific commit using STDIN 
+echo "HEAD" | lumen explain -         # Latest commit using STDIN
+
 
 # Ask specific questions about changes
 lumen explain --diff --query "What's the performance impact of these changes?"

--- a/src/command/explain.rs
+++ b/src/command/explain.rs
@@ -2,10 +2,10 @@ use async_trait::async_trait;
 use spinoff::{spinners, Color, Spinner};
 use std::io::Read;
 
-use crate::{error::LumenError, git_entity::GitEntity, provider::LumenProvider};
+use super::{Command, LumenCommand};
 use crate::git_entity::commit::Commit;
 use crate::git_entity::diff::Diff;
-use super::{Command, LumenCommand};
+use crate::{error::LumenError, git_entity::GitEntity, provider::LumenProvider};
 
 pub struct ExplainCommand {
     pub git_entity: GitEntity,
@@ -36,7 +36,6 @@ impl Command for ExplainCommand {
 
 impl ExplainCommand {
     pub fn new(git_entity: GitEntity, query: Option<String>) -> Result<Self, LumenError> {
-
         let git_entity = match git_entity {
             GitEntity::Diff(Diff::WorkingTree { staged, diff }) if diff == "-" => {
                 // Handle Diff with "-" by reading from stdin
@@ -67,9 +66,6 @@ impl ExplainCommand {
             _ => git_entity,
         };
 
-        Ok(ExplainCommand {
-            git_entity,
-            query,
-        })
+        Ok(ExplainCommand { git_entity, query })
     }
 }

--- a/src/command/explain.rs
+++ b/src/command/explain.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
 use spinoff::{spinners, Color, Spinner};
+use std::io::Read;
 
 use crate::{error::LumenError, git_entity::GitEntity, provider::LumenProvider};
-
+use crate::git_entity::commit::Commit;
+use crate::git_entity::diff::Diff;
 use super::{Command, LumenCommand};
 
 pub struct ExplainCommand {
@@ -29,5 +31,45 @@ impl Command for ExplainCommand {
 
         LumenCommand::print_with_mdcat(result)?;
         Ok(())
+    }
+}
+
+impl ExplainCommand {
+    pub fn new(git_entity: GitEntity, query: Option<String>) -> Result<Self, LumenError> {
+
+        let git_entity = match git_entity {
+            GitEntity::Diff(Diff::WorkingTree { staged, diff }) if diff == "-" => {
+                // Handle Diff with "-" by reading from stdin
+                let mut buffer = String::new();
+                std::io::stdin()
+                    .read_to_string(&mut buffer)
+                    .map_err(LumenError::from)?;
+
+                println!("Replacing '-' with input for Diff: '{}'", buffer.trim());
+
+                GitEntity::Diff(Diff::WorkingTree {
+                    staged,
+                    diff: buffer.trim().to_string(),
+                })
+            }
+
+            GitEntity::Commit(commit_sha) if commit_sha.to_string() == "-" => {
+                // Handle Commit with "-" by reading from stdin
+                let mut buffer = String::new();
+                std::io::stdin()
+                    .read_to_string(&mut buffer)
+                    .map_err(LumenError::from)?;
+
+                println!("Replacing '-' with input for Commit: '{}'", buffer.trim());
+
+                GitEntity::Commit(Commit::new(buffer.trim().to_string())?)
+            }
+            _ => git_entity,
+        };
+
+        Ok(ExplainCommand {
+            git_entity,
+            query,
+        })
     }
 }

--- a/src/command/list.rs
+++ b/src/command/list.rs
@@ -17,8 +17,8 @@ impl Command for ListCommand {
         let git_entity = GitEntity::Commit(Commit::new(sha)?);
 
         // "new" to create ExplainCommand
-        ExplainCommand::new(git_entity,None)?
-        .execute(provider)
-        .await
+        ExplainCommand::new(git_entity, None)?
+            .execute(provider)
+            .await
     }
 }

--- a/src/command/list.rs
+++ b/src/command/list.rs
@@ -15,10 +15,9 @@ impl Command for ListCommand {
     async fn execute(&self, provider: &LumenProvider) -> Result<(), LumenError> {
         let sha = LumenCommand::get_sha_from_fzf()?;
         let git_entity = GitEntity::Commit(Commit::new(sha)?);
-        ExplainCommand {
-            git_entity,
-            query: None,
-        }
+
+        // "new" to create ExplainCommand
+        ExplainCommand::new(git_entity,None)?
         .execute(provider)
         .await
     }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -33,8 +33,9 @@ impl CommandType {
     pub fn create_command(self) -> Result<Box<dyn Command>, LumenError> {
         Ok(match self {
             CommandType::Explain { git_entity, query } => {
-                Box::new(ExplainCommand { git_entity, query })
+                Box::new(ExplainCommand::new(git_entity, query)?)
             }
+
             CommandType::List => Box::new(ListCommand),
             CommandType::Draft(context, draft_config) => Box::new(DraftCommand {
                 git_entity: GitEntity::Diff(Diff::from_working_tree(true)?),

--- a/src/git_entity/commit.rs
+++ b/src/git_entity/commit.rs
@@ -1,5 +1,5 @@
-use std::io::Read;
 use crate::error::LumenError;
+use std::io::Read;
 use std::process::Command;
 use thiserror::Error;
 

--- a/src/git_entity/commit.rs
+++ b/src/git_entity/commit.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use crate::error::LumenError;
 use std::process::Command;
 use thiserror::Error;
@@ -33,6 +34,18 @@ impl Commit {
             author_email: Self::get_author_email(&sha)?,
             date: Self::get_date(&sha)?,
         })
+    }
+
+    pub fn new_from_stdin() -> Result<Self, LumenError> {
+        let mut buffer = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buffer)
+            .map_err(LumenError::from)?;
+
+        eprintln!("Reading commit SHA from stdin: '{}'", buffer.trim());
+
+        // Assuming you want to create the commit based on the SHA read from stdin
+        Commit::new(buffer.trim().to_string())
     }
 
     pub fn is_valid_commit(sha: &str) -> Result<(), LumenError> {
@@ -120,5 +133,9 @@ impl Commit {
         let mut date = String::from_utf8(output.stdout)?;
         date.pop(); // Remove trailing newline
         Ok(date)
+    }
+
+    pub fn to_string(&self) -> String {
+        self.full_hash.clone()
     }
 }

--- a/src/git_entity/commit.rs
+++ b/src/git_entity/commit.rs
@@ -1,5 +1,4 @@
 use crate::error::LumenError;
-use std::io::Read;
 use std::process::Command;
 use thiserror::Error;
 
@@ -34,18 +33,6 @@ impl Commit {
             author_email: Self::get_author_email(&sha)?,
             date: Self::get_date(&sha)?,
         })
-    }
-
-    pub fn new_from_stdin() -> Result<Self, LumenError> {
-        let mut buffer = String::new();
-        std::io::stdin()
-            .read_to_string(&mut buffer)
-            .map_err(LumenError::from)?;
-
-        eprintln!("Reading commit SHA from stdin: '{}'", buffer.trim());
-
-        // Assuming you want to create the commit based on the SHA read from stdin
-        Commit::new(buffer.trim().to_string())
     }
 
     pub fn is_valid_commit(sha: &str) -> Result<(), LumenError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,6 @@ async fn run() -> Result<(), LumenError> {
             staged,
             query,
         } => {
-
             let git_entity = if diff {
                 GitEntity::Diff(Diff::from_working_tree(staged)?)
             } else if let Some(CommitReference::Single(sha)) = reference {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use clap::Parser;
 use commit_reference::CommitReference;
 use config::cli::{Cli, Commands};
@@ -47,7 +48,15 @@ async fn run() -> Result<(), LumenError> {
             } else if let Some(CommitReference::Single(sha)) = reference {
                 if sha == "-" {
                     // Pass `-` as an indicator to read from stdin
-                    GitEntity::Commit(Commit::new_from_stdin()?)
+                    let mut buffer = String::new();
+                    std::io::stdin()
+                        .read_to_string(&mut buffer)
+                        .map_err(LumenError::from)?;
+
+                    eprintln!("Reading commit SHA from stdin: '{}'", buffer.trim());
+
+                    // Assuming you want to create the commit based on the SHA read from stdin
+                    GitEntity::Commit(Commit::new(buffer.trim().to_string())?)
                 } else {
                     GitEntity::Commit(Commit::new(sha)?)
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,10 +42,16 @@ async fn run() -> Result<(), LumenError> {
             staged,
             query,
         } => {
+
             let git_entity = if diff {
                 GitEntity::Diff(Diff::from_working_tree(staged)?)
             } else if let Some(CommitReference::Single(sha)) = reference {
-                GitEntity::Commit(Commit::new(sha)?)
+                if sha == "-" {
+                    // Pass `-` as an indicator to read from stdin
+                    GitEntity::Commit(Commit::new_from_stdin()?)
+                } else {
+                    GitEntity::Commit(Commit::new(sha)?)
+                }
             } else if let Some(CommitReference::Range { from, to }) = reference {
                 GitEntity::Diff(Diff::from_commits_range(&from, &to)?)
             } else {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,3 +1,4 @@
+use crate::config::cli::ProviderType;
 use async_trait::async_trait;
 use claude::{ClaudeConfig, ClaudeProvider};
 use groq::{GroqConfig, GroqProvider};
@@ -6,7 +7,6 @@ use openai::{OpenAIConfig, OpenAIProvider};
 use openrouter::{OpenRouterConfig, OpenRouterProvider};
 use phind::{PhindConfig, PhindProvider};
 use thiserror::Error;
-use crate::config::cli::ProviderType;
 
 use crate::{
     ai_prompt::{AIPrompt, AIPromptError},


### PR DESCRIPTION
Closes #24 

## Description: 

Refactor Commit Handling and Improve `ExplainCommand`

### **Summary of Changes:**

This pull request introduces several improvements to the `ExplainCommand` functionality, including handling the `"-"` commit SHA in a more flexible and user-friendly way. The key changes are:

1. **Handling `"-"` Commit SHA by Reading from stdin:**
   - The commit SHA `"-"` is now treated as a signal to read the commit SHA from stdin, rather than trying to find a commit with the SHA `"-"`.
   - This feature enables more interactive usage, where users can pass the commit SHA via standard input. For example:
     ```bash
     echo "HEAD" | lumen explain -
     ```
   - When `"-"` is provided as the commit SHA, the program will read the commit SHA from stdin and process it.

2. **Refactor `ExplainCommand` to Handle Special Commit and Diff Cases:**
   - We refactored `ExplainCommand` to handle both `GitEntity::Commit` and `GitEntity::Diff` cases when `"-"` is encountered, allowing the program to read the commit SHA or diff from stdin accordingly.

3. **New `Commit::new_from_stdin` Method:**
   - Added a `new_from_stdin()` method to the `Commit` struct to read the commit SHA from stdin and create the `GitEntity::Commit` object dynamically. This method is used when the commit SHA is `"-"`.

### **Detailed Changes:**
- **`ExplainCommand` Updates:** The `ExplainCommand::new` function now handles `"-"` commit SHAs by reading from stdin. This enables the user to dynamically provide commit SHAs through standard input.
- **`Commit` Updates:** Introduced a new method `Commit::new_from_stdin()` to facilitate commit creation from stdin input, making the command more flexible for interactive use.
- **Refactored `main.rs` and `mod.rs`:** Changes in `main.rs` ensure that the commit SHA `"-"` is passed to the `Commit::new_from_stdin()` method, rather than being treated as an invalid commit. Additionally, `mod.rs` was updated to use the new `ExplainCommand::new()` method.

### **Why These Changes?**
- **Improved Flexibility:** By allowing stdin input for commit SHAs and diffs, the command becomes more interactive and user-friendly, making it easier for users to explore and explain commits dynamically.
- **Cleaner Code:** The refactor improves code structure, making it more maintainable by centralizing the logic for reading from stdin and handling special cases (`"-"`).
