### PR TITLE
Add trick for copy commit message to clipboard on Linux Wayland…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ lumen list
 ```bash
 # Copy commit message to clipboard
 lumen draft | pbcopy                  # macOS
-lumen draft | xclip -selection c      # Linux
+lumen draft | xclip -selection c      # Linux on X11
+lumen draft | wl-copy                 # Linux on Wayland
 
 # Open in your favorite editor
 lumen draft | code -      


### PR DESCRIPTION
`wl-copy` from [wl-clipboard](https://github.com/bugaevc/wl-clipboard) is a modern wayland implementation of [xclip](https://github.com/astrand/xclip).

Recently more Linux users have fallen for Wayland, so `wl-clipboard` is an interesting Tip!