### PR TITLE
feat(commit-reference): add support for triple-dot syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ lumen explain HEAD                    # Latest commit
 lumen explain abc123f                 # Specific commit
 lumen explain HEAD~3..HEAD            # Last 3 commits
 lumen explain main..feature/A         # Branch comparison
+lumen explain main...feature/A        # Branch comparison (merge base)
 
 # Ask specific questions about changes
 lumen explain --diff --query "What's the performance impact of these changes?"

--- a/src/commit_reference.rs
+++ b/src/commit_reference.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 pub enum CommitReference {
     Single(String),
     Range { from: String, to: String },
+    TripleDots { from: String, to: String },
 }
 
 #[derive(Debug, Error)]
@@ -21,8 +22,16 @@ impl FromStr for CommitReference {
             return Err(ReferenceParseError::Empty);
         }
 
-        // Handle the .. cases
-        if let Some((from, to)) = s.split_once("..") {
+        // Handle the ... and .. cases
+        if let Some((from, to)) = s.split_once("...") {
+            let from = if from.is_empty() { "HEAD" } else { from };
+            let to = if to.is_empty() { "HEAD" } else { to };
+
+            Ok(CommitReference::TripleDots {
+                from: from.to_string(),
+                to: to.to_string(),
+            })
+        } else if let Some((from, to)) = s.split_once("..") {
             let from = if from.is_empty() { "HEAD" } else { from };
             let to = if to.is_empty() { "HEAD" } else { to };
 

--- a/src/git_entity/diff.rs
+++ b/src/git_entity/diff.rs
@@ -40,12 +40,15 @@ impl Diff {
         Ok(Diff::WorkingTree { staged, diff })
     }
 
-    pub fn from_commits_range(from: &str, to: &str) -> Result<Self, LumenError> {
+    pub fn from_commits_range(from: &str, to: &str, triple_dot: bool) -> Result<Self, LumenError> {
         let _ = Commit::is_valid_commit(from)?;
         let _ = Commit::is_valid_commit(to)?;
 
+        let separator = if triple_dot { "..." } else { ".." };
+        let range = format!("{}{}{}", from, separator, to);
+
         let output = std::process::Command::new("git")
-            .args(["diff", from, to])
+            .args(["diff", &range])
             .output()?;
 
         let diff = String::from_utf8(output.stdout)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,9 @@ async fn run() -> Result<(), LumenError> {
                 };
                 GitEntity::Commit(Commit::new(sha)?)
             } else if let Some(CommitReference::Range { from, to }) = reference {
-                GitEntity::Diff(Diff::from_commits_range(&from, &to)?)
+                GitEntity::Diff(Diff::from_commits_range(&from, &to, false)?)
+            }  else if let Some(CommitReference::TripleDots { from, to }) = reference {
+                GitEntity::Diff(Diff::from_commits_range(&from, &to, true)?)
             } else {
                 return Err(LumenError::InvalidArguments(
                     "`explain` expects SHA-1 or --diff to be present".into(),


### PR DESCRIPTION
Enhances commit reference handling by introducing support for the triple-dot syntax in commit ranges. This allows users to specify comparison ranges more flexibly, improving the functionality of the diff command.