### PR TITLE
fix: Make second pop in commit message conditional

### DIFF
--- a/src/git_entity/commit.rs
+++ b/src/git_entity/commit.rs
@@ -81,7 +81,9 @@ impl Commit {
 
         let mut message = String::from_utf8(output.stdout)?;
         message.pop(); // Remove trailing newline
-        message.pop();
+        if message.ends_with('\n') {
+            message.pop();  // Remove the second trailing newline in commits where it exists (the ones not from github GUI)
+        }        
         Ok(message)
     }
 


### PR DESCRIPTION
There was an accidental message.pop() in the commit message, leading to the last character of the commit message not printing.