### PR TITLE
Add option to change the base_url of openai provider

### DIFF
--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -52,6 +52,7 @@ pub enum ProviderType {
     Gemini,
     Xai,
     Vercel,
+    Customopenai
 }
 
 impl FromStr for ProviderType {
@@ -68,6 +69,7 @@ impl FromStr for ProviderType {
             "gemini" => Ok(ProviderType::Gemini),
             "xai" => Ok(ProviderType::Xai),
             "vercel" => Ok(ProviderType::Vercel),
+            "customopenai" => Ok(ProviderType::Customopenai),
             _ => Err(format!("Unknown provider: {}", s)),
         }
     }

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -34,6 +34,9 @@ pub struct Cli {
     #[arg(value_enum, long = "vcs")]
     pub vcs: Option<VcsOverride>,
 
+    #[arg(short = 'u', long = "base-url")]
+    pub base_url: Option<String>,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -24,6 +24,9 @@ pub struct LumenConfig {
     #[serde(default = "default_api_key")]
     pub api_key: Option<String>,
 
+    #[serde(default = "default_base_url")]
+    pub base_url: Option<String>,
+
     #[serde(default = "default_draft_config")]
     pub draft: DraftConfig,
 
@@ -82,6 +85,10 @@ fn default_api_key() -> Option<String> {
     std::env::var("LUMEN_API_KEY").ok()
 }
 
+fn default_base_url() -> Option<String> {
+    std::env::var("LUMEN_BASE_URL").ok()
+}
+
 fn deserialize_commit_types<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
@@ -119,11 +126,13 @@ impl LumenConfig {
         let provider = cli.provider.as_ref().cloned().unwrap_or(config.provider);
         let api_key = cli.api_key.clone().or(config.api_key);
         let model = cli.model.clone().or(config.model);
+        let base_url = cli.base_url.clone().or(config.base_url);
 
         Ok(LumenConfig {
             provider,
             model,
             api_key,
+            base_url,
             draft: config.draft,
             theme: config.theme,
         })
@@ -151,6 +160,7 @@ impl Default for LumenConfig {
             api_key: default_api_key(),
             draft: default_draft_config(),
             theme: None,
+            base_url: default_base_url(),
         }
     }
 }

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -80,6 +80,13 @@ pub const ALL_PROVIDERS: &[ProviderInfo] = &[
         default_model: "anthropic/claude-sonnet-4.5",
         env_key: "VERCEL_API_KEY",
     },
+    ProviderInfo {
+        id: "customopenai",
+        provider_type: ProviderType::Customopenai,
+        display_name: "Custom OpenAI",
+        default_model: "gpt-5-mini",
+        env_key: "CUSTOMOPENAI_API_KEY",
+    },
 ];
 
 impl ProviderInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ async fn run() -> Result<(), LumenError> {
     };
 
     let provider =
-        provider::LumenProvider::new(client, config.provider, config.api_key, config.model, config.base_url)?;
+        provider::LumenProvider::new(config.provider, config.api_key, config.model, config.base_url)?;
     let command = command::LumenCommand::new(provider);
 
     // Get VCS backend based on CLI override or auto-detection

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,8 @@ async fn run() -> Result<(), LumenError> {
         Err(e) => return Err(e),
     };
 
-    let provider = provider::LumenProvider::new(config.provider, config.api_key, config.model)?;
+    let provider =
+        provider::LumenProvider::new(client, config.provider, config.api_key, config.model, config.base_url)?;
     let command = command::LumenCommand::new(provider);
 
     // Get VCS backend based on CLI override or auto-detection

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -48,6 +48,17 @@ impl LumenProvider {
         model: Option<String>,
         base_url: Option<String>,
     ) -> Result<Self, LumenError> {
+        if (base_url.is_some())
+            && !matches!(
+                provider_type,
+                ProviderType::Customopenai
+            )
+        {
+            return Err(LumenError::ConfigurationError(
+                "Base URL can only be set for CustomOpenAI provider".to_string(),
+            ));
+        }
+
         let (backend, provider_name) = match provider_type {
             // Custom endpoint providers (OpenRouter, Vercel) - use ServiceTargetResolver
             ProviderType::Openrouter | ProviderType::Vercel | ProviderType::Customopenai => {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -65,7 +65,7 @@ impl LumenProvider {
                 let defaults = ProviderInfo::for_provider(provider_type);
                 let config = match provider_type {
                     ProviderType::OpencodeZen => CustomProviderConfig {
-                        endpoint: "https://opencode.ai/zen/v1/",
+                        endpoint: "https://opencode.ai/zen/v1/".to_string(),
                         env_key: defaults.env_key,
                         adapter_kind: AdapterKind::OpenAI,
                     },

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -46,6 +46,7 @@ impl LumenProvider {
         provider_type: ProviderType,
         api_key: Option<String>,
         model: Option<String>,
+        base_url: Option<String>,
     ) -> Result<Self, LumenError> {
         let (backend, provider_name) = match provider_type {
             // Custom endpoint providers (OpenRouter, Vercel) - use ServiceTargetResolver
@@ -60,6 +61,14 @@ impl LumenProvider {
                     ProviderType::Vercel => CustomProviderConfig {
                         // Trailing slash is required for URL joining to work correctly
                         endpoint: "https://ai-gateway.vercel.sh/v1/",
+                        env_key: defaults.env_key,
+                        adapter_kind: AdapterKind::OpenAI,
+                    },
+                    ProviderType::OpenAI => CustomProviderConfig {
+                        // Trailing slash is required for URL joining to work correctly
+                        endpoint: base_url
+                            .as_deref()
+                            .unwrap_or("https://api.openai.com/v1/"),
                         env_key: defaults.env_key,
                         adapter_kind: AdapterKind::OpenAI,
                     },
@@ -100,7 +109,6 @@ impl LumenProvider {
                     },
                     defaults.display_name.to_string(),
                 )
-            }
             // Native genai providers
             _ => {
                 let defaults = ProviderInfo::for_provider(provider_type);


### PR DESCRIPTION
This PR Adds an option to change the openai base URL (for use in proxys or local llm with OpenAI-style API support).

The cli option is -u
The env is LUMEN_BASE_URL

Sorry i'm not proficient in rust so not sure about correct coding conventions or style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a Custom OpenAI provider with its own default model (gpt-5-mini) and env var for credentials.
  * New CLI option -u / --base-url and corresponding environment variable to specify a custom API base URL.
  * Base URL is applied when using the Custom OpenAI provider.
* **Bug Fixes / Validation**
  * Prevents setting a base URL for non-custom providers to avoid misconfiguration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->