### PR TITLE
Update flake.nix: changed URL literals to strings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "A command-line tool that uses AI to streamline your git workflow - from generating commit messages to explaining complex changes, all without requiring an API key.";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
-    flake-utils.url = github:numtide/flake-utils;
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }:


### PR DESCRIPTION
URL literals cause confusion as they use the same x:x syntax as lambdas. The use of these is considered to be a bad practice. Apart from that, Lix which is a Nix fork dropped support of this feature with its 2.92 release making building of Lumen with it result in an error.