### PR TITLE
[Enhancement] Changes have been implemented to integrate the lumen list functionality into lumen explain --list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A command-line tool that uses AI to streamline your git workflow - generate comm
 ### Prerequisites
 Before you begin, ensure you have:
 1. `git` installed on your system
-2. [fzf](https://github.com/junegunn/fzf) (optional) - Required for `lumen list` command
+2. [fzf](https://github.com/junegunn/fzf) (optional) - Required for `lumen explain --list` command
 3. [mdcat](https://github.com/swsnr/mdcat) (optional) - Required for pretty output formatting
 
 ### Installation
@@ -137,12 +137,17 @@ lumen explain main...feature/A        # Branch comparison (merge base)
 # Ask specific questions about changes
 lumen explain --query "What's the performance impact of these changes?"
 lumen explain HEAD --query "What are the potential side effects?"
+
+# Interactive commit selection
+lumen explain --list                  # Select commit interactively
 ```
 
 ### Interactive Mode
 ```bash
 # Launch interactive fuzzy finder to search through commits (requires: fzf)
-lumen list
+lumen explain --list
+
+# Deprecated: lumen list (use lumen explain --list instead)
 ```
 
 ### Tips & Tricks

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -58,7 +58,7 @@ impl LumenCommand {
         }
     }
 
-    fn get_sha_from_fzf() -> Result<String, LumenError> {
+    pub(crate) fn get_sha_from_fzf() -> Result<String, LumenError> {
         let command = "git log --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' | fzf --ansi --reverse --bind='enter:become(echo {1})'";
 
         let output = std::process::Command::new("sh")

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -61,7 +61,7 @@ impl FromStr for ProviderType {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Explain the changes in a commit, or the current diff (default)
+    /// Explain the changes in a commit, or the current diff (default). Use --list to select commit interactively
     Explain {
         /// Commit reference: SHA, HEAD, HEAD~3..HEAD, main..feature, main...feature
         #[arg(value_parser = clap::value_parser!(CommitReference))]
@@ -74,6 +74,10 @@ pub enum Commands {
         /// Ask a question instead of summary
         #[arg(short, long)]
         query: Option<String>,
+
+        /// Select commit interactively using fuzzy finder
+        #[arg(long)]
+        list: bool,
     },
     /// List all commits in an interactive fuzzy-finder, and summarize the changes
     List,


### PR DESCRIPTION

**Code Changes Made:**
_CLI Configuration (cli.rs):_
Added --list flag to the Explain subcommand
Updated the help text to mention interactive selection

_Main Logic (main.rs):_
Modified the Explain command handling to check for --list flag When --list is used, it calls the fuzzy finder to select a commit interactively Added deprecation warning for the List command
Prioritizes --list over any provided reference if both are specified

_Command Module (mod.rs):_
Made get_sha_from_fzf() method public within the crate for reuse

_README.md_ is now accurately documents the new integrated functionality while maintaining backward compatibility information.

**Behavior Changes:**
`lumen explain --list` now provides the same interactive commit selection as lumen list
`lumen list` still works but shows a deprecation warning directing users to `lumen explain --list`
The --list flag integrates seamlessly with existing explain features like --query
If both --list and a reference are provided, --list takes precedence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive commit selection workflow via `lumen explain --list` command

* **Deprecated**
  * `lumen list` command is now deprecated; use `lumen explain --list` for interactive selection

* **Documentation**
  * Updated prerequisites to reflect fzf is optional, required only for `lumen explain --list`

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->