### PR TITLE
fix: use correct AI model names and respect provider-specific env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,24 +201,24 @@ Configure your preferred AI provider:
 
 ```bash
 # Using CLI arguments
-lumen -p openai -k "your-api-key" -m "gpt-5-mini" draft
+lumen -p openai -k "your-api-key" -m "gpt-4o-mini" draft
 
 # Using environment variables
 export LUMEN_AI_PROVIDER="openai"
 export LUMEN_API_KEY="your-api-key"
-export LUMEN_AI_MODEL="gpt-5-mini"
+export LUMEN_AI_MODEL="gpt-4o-mini"
 ```
 
 ### Supported Providers
 
 | Provider | API Key Required | Models |
 |----------|-----------------|---------|
-| [OpenAI](https://platform.openai.com/docs/models) `openai` (Default) | Yes | `gpt-5.2`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `o4-mini` (default: `gpt-5-mini`) |
-| [Claude](https://www.anthropic.com/pricing) `claude` | Yes | `claude-sonnet-4-5-20250930`, `claude-opus-4-5-20251115`, `claude-haiku-4-5-20251015` (default: `claude-sonnet-4-5-20250930`) |
-| [Gemini](https://ai.google.dev/) `gemini` | Yes (free tier) | `gemini-3-pro`, `gemini-3-flash`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` (default: `gemini-3-flash`) |
-| [Groq](https://console.groq.com/docs/models) `groq` | Yes (free) | `llama-3.3-70b-versatile`, `llama-3.1-8b-instant`, `meta-llama/llama-4-maverick-17b-128e-instruct`, `openai/gpt-oss-120b` (default: `llama-3.3-70b-versatile`) |
-| [DeepSeek](https://www.deepseek.com/) `deepseek` | Yes | `deepseek-chat` (V3.2), `deepseek-reasoner` (default: `deepseek-chat`) |
-| [xAI](https://x.ai/) `xai` | Yes | `grok-4`, `grok-4-mini`, `grok-4-mini-fast` (default: `grok-4-mini-fast`) |
+| [OpenAI](https://platform.openai.com/docs/models) `openai` (Default) | Yes | `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-3.5-turbo` (default: `gpt-4o-mini`) |
+| [Claude](https://www.anthropic.com/pricing) `claude` | Yes | `claude-sonnet-4-5-20250929`, `claude-opus-4-5-20251101`, `claude-haiku-4-5-20251001` (default: `claude-sonnet-4-5-20250929`) |
+| [Gemini](https://ai.google.dev/) `gemini` | Yes (free tier) | `gemini-1.5-pro`, `gemini-1.5-flash`, `gemini-1.0-pro` (default: `gemini-1.5-flash`) |
+| [Groq](https://console.groq.com/docs/models) `groq` | Yes (free) | `llama-3.3-70b-versatile`, `llama-3.1-8b-instant`, `mixtral-8x7b-32768` (default: `llama-3.3-70b-versatile`) |
+| [DeepSeek](https://www.deepseek.com/) `deepseek` | Yes | `deepseek-chat`, `deepseek-reasoner` (default: `deepseek-chat`) |
+| [xAI](https://x.ai/) `xai` | Yes | `grok-beta`, `grok-2` (default: `grok-beta`) |
 | [Ollama](https://github.com/ollama/ollama) `ollama` | No (local) | [see list](https://ollama.com/library) (default: `llama3.2`) |
 | [OpenRouter](https://openrouter.ai/) `openrouter` | Yes | [see list](https://openrouter.ai/models) (default: `anthropic/claude-sonnet-4.5`) |
 | [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) `vercel` | Yes | [see list](https://vercel.com/docs/ai-gateway/supported-models) (default: `anthropic/claude-sonnet-4.5`) |
@@ -244,7 +244,7 @@ Lumen will load configurations in the following order of priority:
 ```json
 {
   "provider": "openai",
-  "model": "gpt-5-mini",
+  "model": "gpt-4o-mini",
   "api_key": "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
   "draft": {
     "commit_types": {
@@ -275,7 +275,7 @@ Example: Using different providers for different projects:
 ```bash
 # Set global defaults in .zshrc/.bashrc
 export LUMEN_AI_PROVIDER="openai"
-export LUMEN_AI_MODEL="gpt-5-mini"
+export LUMEN_AI_MODEL="gpt-4o-mini"
 export LUMEN_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxx"
 
 # Override per project using config file

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -110,17 +110,17 @@ impl LumenProvider {
             // Native genai providers
             _ => {
                 let (default_model, name, env_key) = match provider_type {
-                    ProviderType::Openai => ("gpt-5-mini", "OpenAI", "OPENAI_API_KEY"),
+                    ProviderType::Openai => ("gpt-4o-mini", "OpenAI", "OPENAI_API_KEY"),
                     ProviderType::Claude => (
-                        "claude-sonnet-4-5-20250930",
+                        "claude-sonnet-4-5-20250929",
                         "Claude",
                         "ANTHROPIC_API_KEY",
                     ),
                     ProviderType::Groq => ("llama-3.3-70b-versatile", "Groq", "GROQ_API_KEY"),
                     ProviderType::Ollama => ("llama3.2", "Ollama", ""),
                     ProviderType::Deepseek => ("deepseek-chat", "DeepSeek", "DEEPSEEK_API_KEY"),
-                    ProviderType::Gemini => ("gemini-3-flash", "Gemini", "GEMINI_API_KEY"),
-                    ProviderType::Xai => ("grok-4-mini-fast", "xAI", "XAI_API_KEY"),
+                    ProviderType::Gemini => ("gemini-1.5-flash", "Gemini", "GEMINI_API_KEY"),
+                    ProviderType::Xai => ("grok-beta", "xAI", "XAI_API_KEY"),
                     ProviderType::Openrouter | ProviderType::Vercel => {
                         unreachable!()
                     }
@@ -129,8 +129,9 @@ impl LumenProvider {
                 let model = model.unwrap_or_else(|| default_model.to_string());
 
                 // If api_key provided via CLI/config, set it in env so genai picks it up
+                // But only if the env var isn't already set (allow per-provider env vars to take precedence)
                 if let Some(key) = api_key {
-                    if !env_key.is_empty() {
+                    if !env_key.is_empty() && std::env::var(env_key).is_err() {
                         std::env::set_var(env_key, key);
                     }
                 }


### PR DESCRIPTION
- Update default models to actual current versions:
  - OpenAI: gpt-4o-mini (was gpt-5-mini)
  - Claude: claude-sonnet-4-5-20250929 (was claude-sonnet-4-5-20250930)
  - Gemini: gemini-1.5-flash (was gemini-3-flash)
  - xAI: grok-beta (was grok-4-mini-fast)
  - OpenRouter/Vercel: anthropic/claude-sonnet-4.5

- Only set provider env var from config api_key if env var is not already set This allows using -p flag to switch providers when env vars are configured

- Update README with correct model names for all providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported AI models and default selections across all providers (OpenAI, Claude, Gemini, Groq, DeepSeek, xAI)
  * Configuration examples and environment variable references refreshed

* **Changes**
  * Enhanced API key handling to prevent overwriting pre-existing provider environment variables

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->