### PR TITLE
Fix: trim whitespace in commit refs

### DIFF
--- a/src/git_entity/commit.rs
+++ b/src/git_entity/commit.rs
@@ -68,6 +68,7 @@ impl Commit {
             .args([
                 "diff-tree",
                 "-p",
+                "--root",
                 "--binary",
                 "--no-color",
                 "--compact-summary",
@@ -210,5 +211,13 @@ mod tests {
 
         let result = Commit::is_valid_commit("HEAD\n");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn root_commit_diff_should_not_be_empty() {
+        let _repo = RepoGuard::new();
+
+        let commit = Commit::new("HEAD".to_string()).expect("root commit should load");
+        assert!(!commit.diff.trim().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Trim commit refs before git validation/usage to accept stdin/newline inputs.
- Include root commit diffs by passing `--root` to `git diff-tree`.
- Add regression tests for trailing newline refs and root commit diffs.

## Motivation
Inputs from stdin commonly include a trailing newline (e.g., `echo HEAD | ...`, `git rev-parse HEAD | ...`, `cat sha.txt | ...`), which makes `git cat-file -t` reject the ref. Normalizing refs at the point of use makes behavior consistent across input sources. Also, root commits currently surface as empty diffs because `git diff-tree` omits them without `--root`. That causes initial commits to fail with `EmptyDiff`, even when files were added.\n
## Test Plan
- [x] cargo test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit metadata and full content are now accessible programmatically; commit dates are returned in raw git output format.

* **Bug Fixes**
  * Robust trimming of commit identifiers and messages (handles trailing whitespace/newlines).
  * Diff retrieval improved: correctly applies exclusions and reports empty diffs for root/empty commits.

* **Tests**
  * Added tests for identifier edge cases and diff handling.

* **Documentation**
  * API docs clarified for commit-related behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->