### PR TITLE
feat(prompt): add optional user config to prompts

### DIFF
--- a/src/command/configure.rs
+++ b/src/command/configure.rs
@@ -104,7 +104,7 @@ impl ConfigureCommand {
     }
 
     /// Resolves the path to the configuration directory (`~/.config/lumen`).
-    fn get_config_path() -> Result<std::path::PathBuf, LumenError> {
+    pub fn get_config_path() -> Result<std::path::PathBuf, LumenError> {
         let mut path = home_dir().ok_or_else(|| {
             LumenError::ConfigurationError("Could not determine home directory".to_string())
         })?;


### PR DESCRIPTION
Add support for loading optional markdown files as user preferences for explain, draft, and operate prompts. Also restructure prompt generation to separate markdown config from command-specific content.

Happy to adjust or drop this if it doesn’t fit the project direction.
I went ahead and implemented it to provide something concrete to review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now provide custom markdown configuration snippets to personalize AI prompts for explain, draft, and operate commands.

* **Refactor**
  * Enhanced prompt construction to support optional user configuration sections within the AI prompt workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->