### PR TITLE
chore: fix nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,17 @@
   "nodes": {
     "fenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1767941162,
-        "narHash": "sha256-7qJDycrXto4xrQWHbj5BkrRWt/hcfZtjlCstEJTyfJ8=",
+        "lastModified": 1768113825,
+        "narHash": "sha256-f09fAifGPEuRrz1DFY910jexq0DaBuQBbq7WcxQIUgs=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "80b1a19a713e2558c411f3259fecb1edd4b5b327",
+        "rev": "55106e04d905c6a7726d0f6be77ed39a99f66a61",
         "type": "github"
       },
       "original": {
@@ -39,27 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767767207,
-        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "lastModified": 1768127708,
+        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
         "type": "github"
       },
       "original": {
@@ -73,17 +59,17 @@
       "inputs": {
         "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1767905519,
-        "narHash": "sha256-mRU9VEhGQE9dnOU3pu1Rx3dZO4NpZO+cnC0rPMFcCqE=",
+        "lastModified": 1768083390,
+        "narHash": "sha256-TGWPJq2mXwxfAe83iZ18DIqXC4sOSj7RkW9b59h6Ox4=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "ff9a2e88b14907562294838f83963e5966f717de",
+        "rev": "e42e8ff582ba12a88b6845525d08b6428e6d0fb9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,15 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, fenix, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs { inherit system; };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    fenix,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
       rustToolchain = fenix.packages.${system}.stable.withComponents [
         "cargo"
         "clippy"
@@ -22,23 +27,22 @@
         "rust-src"
       ];
       rust-analyzer = fenix.packages.${system}.rust-analyzer;
-    in
-    {
+    in {
       packages = {
-        lumen = 
-          let
-            manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
-          in
+        lumen = let
+          manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+        in
           pkgs.rustPlatform.buildRustPackage {
             pname = manifest.name;
             version = manifest.version;
-          
+
             cargoLock.lockFile = ./Cargo.lock;
-          
+
             src = pkgs.lib.cleanSource ./.;
-          
-            nativeBuildInputs = [ pkgs.pkg-config ];
-            buildInputs = [ pkgs.openssl ];
+
+            nativeBuildInputs = [pkgs.pkg-config pkgs.perl];
+            buildInputs = [pkgs.openssl];
+            doCheck = false;
           };
         default = self.packages.${system}.lumen;
       };
@@ -48,6 +52,7 @@
           rustToolchain
           rust-analyzer
           pkgs.pkg-config
+          pkgs.perl
         ];
         buildInputs = [
           pkgs.openssl


### PR DESCRIPTION
flake.lock file wasn't up to date, so we had too old of a rust version to use edition=2024 in cargo.toml

also, nix by default runs tests in the pkgs.lib.buildRustPackage which often caused the build to timeout. i disabled this

reopening #106 because i opened that from the wrong branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build environment with improved dependency management, including Perl support for better compatibility
  * Restructured build configuration to improve maintainability and clarity across package definitions
  * Reformatted configuration structure for consistency and reduced redundancy in declarations
  * Development environment now includes Perl alongside existing tooling for comprehensive build system support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->