### PR TITLE
fix(ui): ensure explicit background rendering for light and dark themes

### DIFF
--- a/src/command/diff/render/sidebar.rs
+++ b/src/command/diff/render/sidebar.rs
@@ -21,6 +21,7 @@ pub fn render_sidebar(
     is_focused: bool,
 ) {
     let t = theme::get();
+    let bg = t.ui.footer_bg;
     let visible_height = area.height.saturating_sub(2) as usize;
     let lines: Vec<Line> = sidebar_items
         .iter()
@@ -141,12 +142,14 @@ pub fn render_sidebar(
         .collect();
 
     let para = Paragraph::new(visible_lines)
+    .style(Style::default().bg(bg))
         .scroll((0, sidebar_h_scroll))
         .block(
             Block::default()
                 .title(Line::styled(" [1] Files ", title_style))
                 .borders(Borders::ALL)
-                .border_style(border_style),
+                .border_style(border_style)
+                .style(Style::default().bg(bg)),
         );
 
     frame.render_widget(para, area);

--- a/src/command/diff/theme.rs
+++ b/src/command/diff/theme.rs
@@ -739,7 +739,7 @@ impl Theme {
             },
             ui: UiColors {
                 border_focused: Color::Rgb(38, 139, 210), // blue
-                border_unfocused: Color::Rgb(7, 54, 66),
+                border_unfocused: Color::Rgb(88, 110, 117),
                 text_primary: Color::Rgb(131, 148, 150), // base0
                 text_secondary: Color::Rgb(147, 161, 161), // base1
                 text_muted: Color::Rgb(88, 110, 117),    // base01
@@ -800,7 +800,7 @@ impl Theme {
             },
             ui: UiColors {
                 border_focused: Color::Rgb(38, 139, 210),
-                border_unfocused: Color::Rgb(238, 232, 213),
+                border_unfocused: Color::Rgb(147, 161, 161),
                 text_primary: Color::Rgb(101, 123, 131), // base00
                 text_secondary: Color::Rgb(88, 110, 117), // base01
                 text_muted: Color::Rgb(147, 161, 161),   // base1


### PR DESCRIPTION
Fix TUI background color from theme

Related issue: #95

This PR fixes an issue where the TUI did not apply the background color defined in the selected theme.

Now, when running lumen diff --theme <theme>, the TUI correctly uses the background color specified by the theme instead of falling back to the terminal default.

This ensures themes are fully applied and the visual output matches the expected configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual consistency across diff panels with improved background styling
  * Updated border colors in Solarized Dark and Solarized Light themes for improved readability
  * Refined sidebar appearance with consistent background colors for better visual cohesion

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->