### PR TITLE
feat: Add --focus flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ lumen diff --watch
 
 # Stacked mode - review commits one by one
 lumen diff main..feature --stacked
+
+# Jump to a specific file on open
+lumen diff --focus src/main.rs
 ```
 
 #### Stacked Diff Mode

--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -152,7 +152,7 @@ fn run_app_internal(
         None
     };
 
-    let mut state = AppState::new(file_diffs);
+    let mut state = AppState::new(file_diffs, options.focus.as_deref());
     state.set_vcs_name(backend.name());
 
     // Set diff reference for annotation export context

--- a/src/command/diff/mod.rs
+++ b/src/command/diff/mod.rs
@@ -27,6 +27,7 @@ pub struct DiffOptions {
     pub watch: bool,
     pub theme: Option<String>,
     pub stacked: bool,
+    pub focus: Option<String>,
 }
 
 #[derive(Clone)]

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -131,6 +131,10 @@ pub enum Commands {
         /// Show commits stacked (commit-by-commit navigation with ctrl+l/h)
         #[arg(long)]
         stacked: bool,
+
+        /// Initially focus on this file path
+        #[arg(long)]
+        focus: Option<String>,
     },
     /// Interactively configure Lumen (provider, API key)
     Configure,

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,7 @@ async fn run() -> Result<(), LumenError> {
             watch,
             theme,
             stacked,
+            focus,
         } => {
             let options = command::diff::DiffOptions {
                 reference,
@@ -124,6 +125,7 @@ async fn run() -> Result<(), LumenError> {
                 watch,
                 theme: theme.or(config.theme.clone()),
                 stacked,
+                focus,
             };
             command::diff::run_diff_ui(options, backend.as_ref())?;
         }


### PR DESCRIPTION
# Description

Add a `--focus <filepath>` flag to the `lumen diff` command that controls which file is initially displayed when launching the diff viewer.

**Changes:**
- Added `--focus` CLI argument to the `Diff` command
- Extended `DiffOptions` struct with `focus: Option<String>` field
- Modified `AppState::new()` to accept an optional focus file parameter
- When focus file is found, both the diff view and sidebar selection start on that file
- When focus file is not found, prints a warning and falls back to the first file
- Added 5 unit tests covering focus selection, fallback behavior, and edge cases

**Usage:**
```bash
lumen diff --focus src/main.rs
lumen diff HEAD~3 --focus src/command/diff/app.rs
```

# Context

Previously, when launching `lumen diff`, users had no way to specify which file should be shown first. The viewer always started on the first file alphabetically in the sidebar. This was inconvenient when reviewing diffs with many files but wanting to jump directly to a specific file of interest.

The `--focus` flag solves this by letting users specify the exact file path to display on launch. The existing `--file` flag only filters which files appear in the diff, but doesn't control initial selection. With `--focus`, all files remain visible in the sidebar while the specified file is pre-selected and displayed.

This is useful (for me at least?) when integrating lumen into neovim so that it will open to my currently focused buffer.

# Full disclosure: I don't know Rust and fully vibe coded this 😅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --focus flag to open a diff at a specific file; if not found, the view falls back to the first visible file.

* **Behavior**
  * Opening with a focus selects the matching file in the sidebar when present; otherwise selects the first available file and emits a warning.

* **Documentation**
  * README updated with usage example for the --focus option.

* **Tests**
  * Added tests covering focus selection, fallback behavior, and empty-diff cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->