### PR TITLE
fix: diff shows files as deleted when run from subdirectory

### DIFF
--- a/src/vcs/backend.rs
+++ b/src/vcs/backend.rs
@@ -131,4 +131,7 @@ pub trait VcsBackend {
 
     /// Get the name of this VCS backend ("git" or "jj").
     fn name(&self) -> &'static str;
+
+    /// Get the root path of the repository (working directory).
+    fn repo_root(&self) -> Option<&Path>;
 }

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -786,6 +786,10 @@ impl VcsBackend for GitBackend {
     fn name(&self) -> &'static str {
         "git"
     }
+
+    fn repo_root(&self) -> Option<&Path> {
+        self.repo.workdir()
+    }
 }
 
 #[cfg(test)]

--- a/src/vcs/jj.rs
+++ b/src/vcs/jj.rs
@@ -973,6 +973,10 @@ impl VcsBackend for JjBackend {
     fn name(&self) -> &'static str {
         "jj"
     }
+
+    fn repo_root(&self) -> Option<&Path> {
+        Some(&self.workspace_path)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Running `lumen diff` from a subdirectory incorrectly showed modified files as deleted.

The issue was that file paths were resolved relative to the current working directory instead of the repository root. This fix adds `repo_root()` to `VcsBackend` and uses it to resolve paths correctly.


see before and after when running 'lumen diff' inside lumen/src

<img width="772" height="932" alt="image" src="https://github.com/user-attachments/assets/5690e92a-e77f-488b-950a-9515bdd63d59" />
<img width="764" height="927" alt="image" src="https://github.com/user-attachments/assets/5e6ce90d-f437-4c56-8760-83a591f9b43d" />


 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file diff path resolution so new content is read relative to the repository root when running commands from subdirectories.

* **Tests**
  * Added tests verifying file diff behavior when operating from repository subdirectories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->