### PR TITLE
Refactor sidebar to FilePanel and support bottom layout configuration

### DIFF
--- a/src/command/diff/annotation.rs
+++ b/src/command/diff/annotation.rs
@@ -67,7 +67,8 @@ impl<'a> AnnotationEditor<'a> {
 
         let t = theme::get();
         self.textarea.set_cursor_line_style(Style::default());
-        self.textarea.set_cursor_style(Style::default().bg(t.ui.text_primary).fg(t.ui.bg));
+        self.textarea
+            .set_cursor_style(Style::default().bg(t.ui.text_primary).fg(t.ui.bg));
         self.textarea.set_block(Block::default());
 
         // Move cursor to end
@@ -105,7 +106,10 @@ impl<'a> AnnotationEditor<'a> {
             // Enter handling: with modifiers = newline, without = save
             KeyCode::Enter => {
                 // Shift+Enter, Alt+Enter, or Ctrl+Enter = newline
-                if key.modifiers.intersects(KeyModifiers::SHIFT | KeyModifiers::ALT | KeyModifiers::CONTROL) {
+                if key
+                    .modifiers
+                    .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT | KeyModifiers::CONTROL)
+                {
                     self.textarea.insert_char('\n');
                     AnnotationEditorResult::Continue
                 } else {
@@ -165,18 +169,12 @@ impl<'a> AnnotationEditor<'a> {
         frame.render_widget(Clear, modal_area);
 
         // Extract just the filename without path for cleaner display
-        let short_filename = self
-            .filename
-            .rsplit('/')
-            .next()
-            .unwrap_or(&self.filename);
+        let short_filename = self.filename.rsplit('/').next().unwrap_or(&self.filename);
 
         // Compact title
         let title = format!(
             " {} · L{}-{} ",
-            short_filename,
-            self.line_range.0,
-            self.line_range.1
+            short_filename, self.line_range.0, self.line_range.1
         );
 
         let block = Block::default()

--- a/src/command/diff/git.rs
+++ b/src/command/diff/git.rs
@@ -122,8 +122,7 @@ pub fn load_file_diffs(options: &DiffOptions, backend: &dyn VcsBackend) -> Vec<F
             } else {
                 FileStatus::Modified
             };
-            let is_binary =
-                is_binary_content(&old_content) || is_binary_content(&new_content);
+            let is_binary = is_binary_content(&old_content) || is_binary_content(&new_content);
             FileDiff {
                 filename,
                 old_content,
@@ -182,8 +181,7 @@ pub fn load_pr_file_diffs(pr_info: &PrInfo) -> Result<Vec<FileDiff>, String> {
                 FileStatus::Modified
             };
 
-            let is_binary =
-                is_binary_content(&old_content) || is_binary_content(&new_content);
+            let is_binary = is_binary_content(&old_content) || is_binary_content(&new_content);
             FileDiff {
                 filename,
                 old_content,
@@ -282,8 +280,7 @@ pub fn load_single_commit_diffs(
                 FileStatus::Modified
             };
 
-            let is_binary =
-                is_binary_content(&old_content) || is_binary_content(&new_content);
+            let is_binary = is_binary_content(&old_content) || is_binary_content(&new_content);
             FileDiff {
                 filename,
                 old_content,

--- a/src/command/diff/mod.rs
+++ b/src/command/diff/mod.rs
@@ -9,7 +9,7 @@ mod search;
 mod state;
 mod sticky_lines;
 pub mod theme;
-mod types;
+pub mod types;
 mod watcher;
 
 use std::collections::HashSet;
@@ -27,6 +27,7 @@ pub struct DiffOptions {
     pub watch: bool,
     pub theme: Option<String>,
     pub stacked: bool,
+    pub file_panel_pos: Option<types::FilePanelPosition>,
 }
 
 #[derive(Clone)]

--- a/src/command/diff/render/diff_view.rs
+++ b/src/command/diff/render/diff_view.rs
@@ -12,13 +12,13 @@ use crate::command::diff::search::{MatchPanel, SearchState};
 use crate::command::diff::state::HunkAnnotation;
 use crate::command::diff::theme;
 use crate::command::diff::types::{
-    ChangeType, DiffFullscreen, DiffLine, DiffViewSettings, FileDiff, FocusedPanel, InlineSegment,
-    SidebarItem,
+    ChangeType, DiffFullscreen, DiffLine, DiffViewSettings, FileDiff, FilePanelItem,
+    FilePanelPosition, FocusedPanel, InlineSegment,
 };
 use crate::command::diff::PrInfo;
 
+use super::file_panel::render_file_panel;
 use super::footer::{render_footer, FooterData};
-use super::sidebar::render_sidebar;
 
 /// Render the header bar for stacked diff mode showing commit info with navigation arrows
 fn render_stacked_header(
@@ -92,7 +92,10 @@ fn render_stacked_header(
         Span::styled(" ", spacer_style),
         Span::styled(&id_label, badge_style.fg(t.ui.footer_branch_fg)),
         Span::styled("  ", spacer_style),
-        Span::styled(&truncated_msg, Style::default().fg(t.ui.text_secondary).bg(bg)),
+        Span::styled(
+            &truncated_msg,
+            Style::default().fg(t.ui.text_secondary).bg(bg),
+        ),
     ];
 
     // Calculate widths for centering
@@ -488,7 +491,11 @@ struct DiffLineStyle {
 }
 
 impl DiffLineStyle {
-    fn for_change_type(change_type: ChangeType, bg: Color, t: &crate::command::diff::theme::Theme) -> Self {
+    fn for_change_type(
+        change_type: ChangeType,
+        bg: Color,
+        t: &crate::command::diff::theme::Theme,
+    ) -> Self {
         match change_type {
             ChangeType::Equal => Self {
                 old_bg: Some(bg),
@@ -631,7 +638,10 @@ fn render_annotation_overlays(
         )]));
 
         // Add content lines
-        for content_line in content_lines.iter().take(available_height.saturating_sub(2)) {
+        for content_line in content_lines
+            .iter()
+            .take(available_height.saturating_sub(2))
+        {
             let content_width_inner = border_width.saturating_sub(1);
             let padded_content = format!("{:<width$}", content_line, width = content_width_inner);
             ann_lines.push(Line::from(vec![
@@ -664,18 +674,18 @@ pub fn render_diff(
     frame: &mut Frame,
     diff: &FileDiff,
     _file_diffs: &[FileDiff],
-    sidebar_items: &[SidebarItem],
-    sidebar_visible: &[usize],
+    file_panel_items: &[FilePanelItem],
+    file_panel_visible: &[usize],
     collapsed_dirs: &HashSet<String>,
     current_file: usize,
     scroll: u16,
     h_scroll: u16,
     watching: bool,
-    show_sidebar: bool,
+    show_file_panel: bool,
     focused_panel: FocusedPanel,
-    sidebar_selected: usize,
-    sidebar_scroll: usize,
-    sidebar_h_scroll: u16,
+    file_panel_selected: usize,
+    file_panel_scroll: usize,
+    file_panel_h_scroll: u16,
     viewed_files: &HashSet<usize>,
     settings: &DiffViewSettings,
     hunk_count: usize,
@@ -726,28 +736,55 @@ pub fn render_diff(
         (chunks[0], chunks[1])
     };
 
-    let main_area = if show_sidebar {
-        let sidebar_width = (area.width / 4).clamp(20, 35);
-        let main_chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([Constraint::Length(sidebar_width), Constraint::Min(0)])
-            .split(content_area);
+    let main_area = if show_file_panel {
+        match settings.file_panel_position {
+            FilePanelPosition::Left => {
+                let panel_width = (area.width / 4).clamp(20, 35);
+                let main_chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Length(panel_width), Constraint::Min(0)])
+                    .split(content_area);
 
-        render_sidebar(
-            frame,
-            main_chunks[0],
-            sidebar_items,
-            sidebar_visible,
-            collapsed_dirs,
-            current_file,
-            sidebar_selected,
-            sidebar_scroll,
-            sidebar_h_scroll,
-            viewed_files,
-            focused_panel == FocusedPanel::Sidebar,
-        );
+                render_file_panel(
+                    frame,
+                    main_chunks[0],
+                    file_panel_items,
+                    file_panel_visible,
+                    collapsed_dirs,
+                    current_file,
+                    file_panel_selected,
+                    file_panel_scroll,
+                    file_panel_h_scroll,
+                    viewed_files,
+                    focused_panel == FocusedPanel::FilePanel,
+                );
 
-        main_chunks[1]
+                main_chunks[1]
+            }
+            FilePanelPosition::Bottom => {
+                let panel_height = (content_area.height / 3).clamp(5, 12);
+                let main_chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(0), Constraint::Length(panel_height)])
+                    .split(content_area);
+
+                render_file_panel(
+                    frame,
+                    main_chunks[1],
+                    file_panel_items,
+                    file_panel_visible,
+                    collapsed_dirs,
+                    current_file,
+                    file_panel_selected,
+                    file_panel_scroll,
+                    file_panel_h_scroll,
+                    viewed_files,
+                    focused_panel == FocusedPanel::FilePanel,
+                );
+
+                main_chunks[0]
+            }
+        }
     } else {
         content_area
     };
@@ -908,7 +945,16 @@ pub fn render_diff(
         let content_x = main_area.x + 1;
         let content_start_y = main_area.y + 1;
         let content_width = main_area.width.saturating_sub(2);
-        render_annotation_overlays(frame, &annotation_overlays, content_x, content_start_y, content_width, main_area, bg, t);
+        render_annotation_overlays(
+            frame,
+            &annotation_overlays,
+            content_x,
+            content_start_y,
+            content_width,
+            main_area,
+            bg,
+            t,
+        );
     } else if is_deleted_file {
         let visible_height = main_area.height.saturating_sub(2) as usize;
         let old_context = compute_context_lines(
@@ -1002,7 +1048,16 @@ pub fn render_diff(
         let content_x = main_area.x + 1;
         let content_start_y = main_area.y + 1;
         let content_width = main_area.width.saturating_sub(2);
-        render_annotation_overlays(frame, &annotation_overlays, content_x, content_start_y, content_width, main_area, bg, t);
+        render_annotation_overlays(
+            frame,
+            &annotation_overlays,
+            content_x,
+            content_start_y,
+            content_width,
+            main_area,
+            bg,
+            t,
+        );
     } else {
         let (old_area, new_area) = match diff_fullscreen {
             DiffFullscreen::OldOnly => (Some(main_area), None),
@@ -1094,38 +1149,41 @@ pub fn render_diff(
             None
         };
 
-
         // Check if this line is the last changed line of a hunk (before Equal or end of hunk)
-        let is_last_changed_line_of_hunk = |line_idx: usize, lines: &[&DiffLine]| -> Option<usize> {
-            let current_idx_in_slice = line_idx.saturating_sub(scroll_usize);
-            if current_idx_in_slice >= lines.len() {
-                return None;
-            }
-            let current_line = lines[current_idx_in_slice];
-            // Current line must be a change
-            if matches!(current_line.change_type, ChangeType::Equal) {
-                return None;
-            }
-            // Check next line
-            let next_idx = current_idx_in_slice + 1;
-            let is_last = if next_idx >= lines.len() {
-                // End of visible lines - only consider it "last" if the hunk actually ends here
-                if let Some(hunk_idx) = get_hunk_for_line(line_idx) {
-                    let hunk_end = hunks.get(hunk_idx + 1).copied().unwrap_or(side_by_side.len());
-                    // Check if next absolute line is at or past hunk end, or at end of file
-                    line_idx + 1 >= hunk_end || line_idx + 1 >= side_by_side.len()
-                } else {
-                    false
+        let is_last_changed_line_of_hunk =
+            |line_idx: usize, lines: &[&DiffLine]| -> Option<usize> {
+                let current_idx_in_slice = line_idx.saturating_sub(scroll_usize);
+                if current_idx_in_slice >= lines.len() {
+                    return None;
                 }
-            } else {
-                matches!(lines[next_idx].change_type, ChangeType::Equal)
+                let current_line = lines[current_idx_in_slice];
+                // Current line must be a change
+                if matches!(current_line.change_type, ChangeType::Equal) {
+                    return None;
+                }
+                // Check next line
+                let next_idx = current_idx_in_slice + 1;
+                let is_last = if next_idx >= lines.len() {
+                    // End of visible lines - only consider it "last" if the hunk actually ends here
+                    if let Some(hunk_idx) = get_hunk_for_line(line_idx) {
+                        let hunk_end = hunks
+                            .get(hunk_idx + 1)
+                            .copied()
+                            .unwrap_or(side_by_side.len());
+                        // Check if next absolute line is at or past hunk end, or at end of file
+                        line_idx + 1 >= hunk_end || line_idx + 1 >= side_by_side.len()
+                    } else {
+                        false
+                    }
+                } else {
+                    matches!(lines[next_idx].change_type, ChangeType::Equal)
+                };
+                if is_last {
+                    get_hunk_for_line(line_idx)
+                } else {
+                    None
+                }
             };
-            if is_last {
-                get_hunk_for_line(line_idx)
-            } else {
-                None
-            }
-        };
 
         for (i, diff_line) in visible_lines.iter().enumerate() {
             let line_idx = scroll_usize + i;
@@ -1350,7 +1408,16 @@ pub fn render_diff(
             render_area.width.saturating_sub(2)
         };
 
-        render_annotation_overlays(frame, &annotation_overlays, content_x, content_start_y, content_width, main_area, bg, t);
+        render_annotation_overlays(
+            frame,
+            &annotation_overlays,
+            content_x,
+            content_start_y,
+            content_width,
+            main_area,
+            bg,
+            t,
+        );
     }
 
     render_footer(

--- a/src/command/diff/render/file_panel.rs
+++ b/src/command/diff/render/file_panel.rs
@@ -6,38 +6,38 @@ use ratatui::{
 };
 
 use crate::command::diff::theme;
-use crate::command::diff::types::{FileStatus, SidebarItem};
+use crate::command::diff::types::{FilePanelItem, FileStatus};
 
 #[allow(clippy::too_many_arguments)]
-pub fn render_sidebar(
+pub fn render_file_panel(
     frame: &mut Frame,
     area: Rect,
-    sidebar_items: &[SidebarItem],
-    sidebar_visible: &[usize],
+    file_panel_items: &[FilePanelItem],
+    file_panel_visible: &[usize],
     collapsed_dirs: &HashSet<String>,
     current_file: usize,
-    sidebar_selected: usize,
-    sidebar_scroll: usize,
-    sidebar_h_scroll: u16,
+    file_panel_selected: usize,
+    file_panel_scroll: usize,
+    file_panel_h_scroll: u16,
     viewed_files: &HashSet<usize>,
     is_focused: bool,
 ) {
     let t = theme::get();
     let bg = t.ui.bg;
     let visible_height = area.height.saturating_sub(2) as usize;
-    let lines: Vec<Line> = sidebar_visible
+    let lines: Vec<Line> = file_panel_visible
         .iter()
         .enumerate()
         .map(|(i, item_idx)| {
-            let item = &sidebar_items[*item_idx];
+            let item = &file_panel_items[*item_idx];
             let (prefix, status_symbol, status_color, name, is_current_file, is_viewed) = match item
             {
-                SidebarItem::Directory {
+                FilePanelItem::Directory {
                     name, path, depth, ..
                 } => {
                     let indent = "  ".repeat(*depth);
-                    let all_children_viewed = sidebar_items.iter().all(|child| {
-                        if let SidebarItem::File {
+                    let all_children_viewed = file_panel_items.iter().all(|child| {
+                        if let FilePanelItem::File {
                             path: file_path,
                             file_index,
                             ..
@@ -49,8 +49,8 @@ pub fn render_sidebar(
                         }
                         true
                     });
-                    let has_children = sidebar_items.iter().any(|child| {
-                        if let SidebarItem::File {
+                    let has_children = file_panel_items.iter().any(|child| {
+                        if let FilePanelItem::File {
                             path: file_path, ..
                         } = child
                         {
@@ -82,7 +82,7 @@ pub fn render_sidebar(
                         all_children_viewed && has_children,
                     )
                 }
-                SidebarItem::File {
+                FilePanelItem::File {
                     name,
                     file_index,
                     depth,
@@ -109,7 +109,7 @@ pub fn render_sidebar(
                 }
             };
 
-            let is_selected = i == sidebar_selected;
+            let is_selected = i == file_panel_selected;
             let base_style = if is_selected {
                 Style::default().fg(t.ui.selection_fg).bg(if is_focused {
                     t.ui.selection_bg
@@ -149,13 +149,13 @@ pub fn render_sidebar(
 
     let visible_lines: Vec<Line> = lines
         .into_iter()
-        .skip(sidebar_scroll)
+        .skip(file_panel_scroll)
         .take(visible_height)
         .collect();
 
     let para = Paragraph::new(visible_lines)
         .style(Style::default().bg(bg))
-        .scroll((0, sidebar_h_scroll))
+        .scroll((0, file_panel_h_scroll))
         .block(
             Block::default()
                 .title(Line::styled(" [1] Files ", title_style))

--- a/src/command/diff/render/footer.rs
+++ b/src/command/diff/render/footer.rs
@@ -203,7 +203,10 @@ pub fn render_footer(frame: &mut Frame, footer_area: Rect, data: FooterData) {
                 Span::styled(viewed_indicator, Style::default().fg(t.ui.viewed).bg(bg)),
             ];
             spans.extend(stats_spans);
-            spans.push(Span::styled(watch_indicator, Style::default().fg(t.ui.watching).bg(bg)));
+            spans.push(Span::styled(
+                watch_indicator,
+                Style::default().fg(t.ui.watching).bg(bg),
+            ));
             spans
         };
 
@@ -223,10 +226,7 @@ pub fn render_footer(frame: &mut Frame, footer_area: Rect, data: FooterData) {
                 format!("[0/0] /{} ", data.search_state.query)
             };
             vec![
-                Span::styled(
-                    search_info,
-                    Style::default().fg(t.ui.highlight).bg(bg),
-                ),
+                Span::styled(search_info, Style::default().fg(t.ui.highlight).bg(bg)),
                 Span::styled(
                     " n/N navigate ",
                     Style::default().fg(t.ui.text_muted).bg(bg),
@@ -259,10 +259,7 @@ pub fn render_footer(frame: &mut Frame, footer_area: Rect, data: FooterData) {
                     },
                     Style::default().fg(t.ui.text_muted).bg(bg),
                 ),
-                Span::styled(
-                    " ? help ",
-                    Style::default().fg(t.ui.text_muted).bg(bg),
-                ),
+                Span::styled(" ? help ", Style::default().fg(t.ui.text_muted).bg(bg)),
             ]
         };
 
@@ -277,10 +274,7 @@ pub fn render_footer(frame: &mut Frame, footer_area: Rect, data: FooterData) {
         let padding = footer_width.saturating_sub(left_len + right_len);
 
         let mut final_spans: Vec<Span> = left_line.spans;
-        final_spans.push(Span::styled(
-            " ".repeat(padding),
-            Style::default().bg(bg),
-        ));
+        final_spans.push(Span::styled(" ".repeat(padding), Style::default().bg(bg)));
         final_spans.extend(right_line.spans);
 
         let footer = Paragraph::new(Line::from(final_spans)).style(Style::default().bg(bg));

--- a/src/command/diff/render/mod.rs
+++ b/src/command/diff/render/mod.rs
@@ -1,7 +1,7 @@
 mod diff_view;
+mod file_panel;
 mod footer;
 pub mod modal;
-mod sidebar;
 
 pub use diff_view::{render_diff, render_empty_state};
 pub use footer::truncate_path;

--- a/src/command/diff/theme.rs
+++ b/src/command/diff/theme.rs
@@ -317,7 +317,7 @@ impl Theme {
                 text_secondary: Color::Rgb(166, 173, 200),   // subtext0
                 text_muted: Color::Rgb(108, 112, 134),       // overlay0
                 line_number: Color::Rgb(88, 91, 112),        // overlay0
-                bg: Color::Rgb(24, 24, 37),           // mantle
+                bg: Color::Rgb(24, 24, 37),                  // mantle
                 footer_branch_bg: Color::Rgb(49, 50, 68),    // surface0
                 footer_branch_fg: Color::Rgb(137, 180, 250), // blue
                 status_added: Color::Rgb(166, 227, 161),     // green
@@ -500,7 +500,7 @@ impl Theme {
                 text_secondary: Color::Rgb(216, 222, 233), // nord4
                 text_muted: Color::Rgb(76, 86, 106),       // nord3
                 line_number: Color::Rgb(76, 86, 106),
-                bg: Color::Rgb(59, 66, 82),        // nord1
+                bg: Color::Rgb(59, 66, 82),               // nord1
                 footer_branch_bg: Color::Rgb(67, 76, 94), // nord2
                 footer_branch_fg: Color::Rgb(136, 192, 208),
                 status_added: Color::Rgb(163, 190, 140),

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use std::str::FromStr;
 
+use crate::command::diff::types::FilePanelPosition;
 use crate::commit_reference::CommitReference;
 
 /// VCS backend override option
@@ -131,6 +132,10 @@ pub enum Commands {
         /// Show commits stacked (commit-by-commit navigation with ctrl+l/h)
         #[arg(long)]
         stacked: bool,
+
+        /// File panel position (left, bottom)
+        #[arg(value_enum, long = "file-panel-pos")]
+        file_panel_pos: Option<FilePanelPosition>,
     },
     /// Interactively configure Lumen (provider, API key)
     Configure,

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -1,3 +1,4 @@
+use crate::command::diff::types::FilePanelPosition;
 use crate::config::cli::ProviderType;
 use crate::error::LumenError;
 use dirs::home_dir;
@@ -29,6 +30,9 @@ pub struct LumenConfig {
 
     #[serde(default)]
     pub theme: Option<String>,
+
+    #[serde(default)]
+    pub file_panel_position: FilePanelPosition,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -119,6 +123,12 @@ impl LumenConfig {
         let provider = cli.provider.as_ref().cloned().unwrap_or(config.provider);
         let api_key = cli.api_key.clone().or(config.api_key);
         let model = cli.model.clone().or(config.model);
+        let file_panel_position =
+            if let crate::config::cli::Commands::Diff { file_panel_pos, .. } = &cli.command {
+                file_panel_pos.unwrap_or(config.file_panel_position)
+            } else {
+                config.file_panel_position
+            };
 
         Ok(LumenConfig {
             provider,
@@ -126,6 +136,7 @@ impl LumenConfig {
             api_key,
             draft: config.draft,
             theme: config.theme,
+            file_panel_position,
         })
     }
 
@@ -151,6 +162,7 @@ impl Default for LumenConfig {
             api_key: default_api_key(),
             draft: default_draft_config(),
             theme: None,
+            file_panel_position: FilePanelPosition::default(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,7 @@ async fn run() -> Result<(), LumenError> {
             watch,
             theme,
             stacked,
+            file_panel_pos,
         } => {
             let options = command::diff::DiffOptions {
                 reference,
@@ -124,6 +125,7 @@ async fn run() -> Result<(), LumenError> {
                 watch,
                 theme: theme.or(config.theme.clone()),
                 stacked,
+                file_panel_pos: file_panel_pos.or(Some(config.file_panel_position)),
             };
             command::diff::run_diff_ui(options, backend.as_ref())?;
         }


### PR DESCRIPTION
Implemented #123 

I've used gemini 3 pro (for the first time to just experiment it to understand it's capabilities) to make this configuration possible, please do review it thoroughly

<img width="1548" height="1395" alt="image" src="https://github.com/user-attachments/assets/a37b63f0-a767-4f95-8be2-678f832b7d44" />


### this is what this PR introduced

1. Configurable File Panel Position
*   CLI Flag: --file-panel-pos <left|bottom>
*   Configuration: Added file_panel_position to lumen.config.json.
*   Visuals: In bottom mode, the diff view splits vertically, providing more horizontal space for side-by-side diffs on narrow terminals.

2. Semantic Refactoring (Sidebar → FilePanel)
To better reflect its new capability, the "Sidebar" component has been renamed to "FilePanel" (since Sidebar is no more Sidebar)
*   Renamed src/command/diff/render/sidebar.rs to file_panel.rs.
*   Renamed types and state fields (e.g., SidebarItem → FilePanelItem, sidebar_selected → file_panel_selected).
*   Updated all internal logic and documentation to use the new terminology.

```bash
lumen --diff --file-panel-pos bottom
lumen --diff --file-panel-pos left
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File panel positioning is now configurable: place the file panel on the left or bottom via the `--file-panel-pos` CLI argument or configuration file settings.

* **Updates**
  * Sidebar component renamed to file panel throughout the interface.
  * Keybindings and help text updated to reflect file panel terminology.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->