### PR TITLE
Resolve file paths relative to repo root

### DIFF
--- a/src/vcs/backend.rs
+++ b/src/vcs/backend.rs
@@ -129,6 +129,9 @@ pub trait VcsBackend {
         to: &str,
     ) -> Result<Vec<StackedCommitInfo>, VcsError>;
 
+    /// Get the root path of the repository working directory.
+    fn get_repository_root(&self) -> Result<std::path::PathBuf, VcsError>;
+
     /// Get the name of this VCS backend ("git" or "jj").
     fn name(&self) -> &'static str;
 }

--- a/src/vcs/jj.rs
+++ b/src/vcs/jj.rs
@@ -970,6 +970,10 @@ impl VcsBackend for JjBackend {
         })
     }
 
+    fn get_repository_root(&self) -> Result<std::path::PathBuf, VcsError> {
+        Ok(self.workspace.workspace_root().to_path_buf())
+    }
+
     fn name(&self) -> &'static str {
         "jj"
     }


### PR DESCRIPTION
## Summary
This pull request allows `lumen` to run correctly from a sub directory. Currently, it can't find the files correctly and treats them as being deleted.

## Changes
- Add `get_repository_root()` method to `VcsBackend` trait
- Implement for `GitBackend` (using `repo.workdir()`) and `JjBackend` (using `workspace_path`)
- Update `get_new_content()` to resolve paths from repo root

## Test plan
- Added `test_get_repository_root_from_subdirectory` for GitBackend
- Added `test_load_file_diffs_from_subdirectory` integration test
- Manually verified on an existing git repo but couldn't verify on a jj repo (see Notes section below)

## Repro steps
1. Go to a sub directory
2. Make a change to a file
3. Run `lumen diff`

## Notes

Discovered a pre-existing issue: `JjBackend` cannot be loaded from subdirectories because `Workspace::load()` requires the exact workspace root path (unlike git2's `Repository::discover()` which walks up the directory tree). This is unrelated to this fix - the same error occurs on the current release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file diff/new-content resolution when running the tool from a subdirectory — diffs and updated content are now resolved against the repository root.

* **Tests**
  * Added tests to verify diffs and file content are correctly loaded when operating from within repository subdirectories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->