### PR TITLE
Print errors of libgit2 before returning the VcsError 

### DIFF
--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -137,8 +137,16 @@ impl GitBackend {
     /// Open a git repository at the given path.
     /// Uses git2::Repository::discover to find the repo from any subdirectory.
     pub fn new(path: &Path) -> Result<Self, VcsError> {
-        let repo = Repository::discover(path).map_err(|_| VcsError::NotARepository)?;
-        Ok(GitBackend { repo })
+        let discover_result = Repository::discover(path);//map_err(|_| VcsError::NotARepository)?;
+        return match discover_result {
+            Ok(repo) =>  Ok(GitBackend { repo }),
+            Err(error) => {
+                // Print libgit2 so there is a chance to diagnose any errors with git
+                println!("Error on repository discovery: {error:?}");
+                return Err(VcsError::NotARepository)
+            },
+        };
+
     }
 
     /// Open a git repository from the current working directory.


### PR DESCRIPTION
This PR and its code change is the result of an issue described in #138.

The original code swallows any exception of libgit2 making it impossible to diagnose any errors.

To keep the original logic I kept the return type and just added a `pringln` with the original error provided bi libgit2.

I'm new to rust. If I can do better, please let me know what you want you want differently and I'll do my best to fit the code to your expectations