### PR TITLE
feat: add configurable keybindings for diff TUI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+            name: linux-amd64
+            artifact: lumen-x86_64-linux
+            cross: false
+
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04
+            name: linux-arm64
+            artifact: lumen-aarch64-linux
+            cross: true
+
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            name: macos-intel
+            artifact: lumen-x86_64-darwin
+            cross: false
+
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            name: macos-apple-silicon
+            artifact: lumen-aarch64-darwin
+            cross: false
+
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            name: windows-amd64
+            artifact: lumen-x86_64-windows.exe
+            cross: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross (Linux ARM64 only)
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build binary (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Build binary (native)
+        if: "!matrix.cross"
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Strip binary (Linux)
+        if: runner.os == 'Linux' && !matrix.cross
+        run: strip target/${{ matrix.target }}/release/lumen
+
+      - name: Strip binary (Linux ARM64 via cross)
+        if: matrix.cross
+        run: |
+          docker run --rm \
+            -v "$PWD/target/${{ matrix.target }}/release:/work" \
+            ghcr.io/cross-rs/${{ matrix.target }}:main \
+            aarch64-linux-gnu-strip /work/lumen
+
+      - name: Strip binary (macOS)
+        if: runner.os == 'macOS'
+        run: strip target/${{ matrix.target }}/release/lumen
+
+      - name: Rename binary (Unix)
+        if: runner.os != 'Windows'
+        run: cp target/${{ matrix.target }}/release/lumen ${{ matrix.artifact }}
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        run: cp target/${{ matrix.target }}/release/lumen.exe ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List release artifacts
+        run: ls -lah artifacts/
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: artifacts/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -29,6 +29,7 @@ use super::types::{
     ChangeType, CursorPosition, DiffFullscreen, DiffPanelFocus, FileStatus, FocusedPanel,
     SelectionMode, SidebarItem,
 };
+use super::keybindings::{KeyAction, KeyBindings};
 use super::watcher::{setup_watcher, WatchEvent};
 use super::{
     fetch_viewed_files, mark_file_as_viewed_async, unmark_file_as_viewed_async, DiffOptions, PrInfo,
@@ -176,6 +177,9 @@ fn run_app_internal(
 ) -> io::Result<()> {
     theme::init(options.theme.as_deref());
     highlight::init();
+
+    // Build keybinding lookup from defaults + user overrides.
+    let keybindings = KeyBindings::new(options.keybindings.as_ref());
 
     // Initialize state before TUI so we can sync viewed files
     let mut state = AppState::new(file_diffs, options.focus.as_deref());
@@ -926,87 +930,177 @@ fn run_app_internal(
                         state.pending_key = PendingKey::None;
                     }
                     state.show_selection_tooltip = false;
-                    match key.code {
-                        KeyCode::Esc | KeyCode::Char('c')
-                            if (key.code == KeyCode::Esc
-                                || key.modifiers.contains(KeyModifiers::CONTROL))
-                                && state.selection.is_active() =>
-                        {
-                            // First priority: clear selection
-                            state.clear_selection();
-                        }
-                        KeyCode::Esc | KeyCode::Char('c')
-                            if (key.code == KeyCode::Esc
-                                || key.modifiers.contains(KeyModifiers::CONTROL))
-                                && state.search_state.has_query() =>
-                        {
-                            state.search_state.clear();
-                            state.mark_search_dirty();
-                        }
-                        KeyCode::Char('q') | KeyCode::Esc => break 'main,
-                        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            break 'main
-                        }
-                        KeyCode::Char('1') => {
-                            state.focused_panel = FocusedPanel::Sidebar;
-                            state.show_sidebar = true;
-                            if !matches!(
-                                state.sidebar_item_at_visible(state.sidebar_selected),
-                                Some(SidebarItem::File { .. })
-                            ) {
-                                if let Some(idx) = state.sidebar_visible.iter().position(|idx| {
-                                    matches!(state.sidebar_items[*idx], SidebarItem::File { .. })
-                                }) {
-                                    state.sidebar_selected = idx;
+
+                    // --- Hardcoded priority handlers (selection/search clear) ---
+                    // These must fire before rebindable actions because Esc/Ctrl+C
+                    // serve double duty: clearing state first, quitting second.
+                    if (key.code == KeyCode::Esc
+                        || (key.code == KeyCode::Char('c')
+                            && key.modifiers.contains(KeyModifiers::CONTROL)))
+                        && state.selection.is_active()
+                    {
+                        state.clear_selection();
+                    } else if (key.code == KeyCode::Esc
+                        || (key.code == KeyCode::Char('c')
+                            && key.modifiers.contains(KeyModifiers::CONTROL)))
+                        && state.search_state.has_query()
+                    {
+                        state.search_state.clear();
+                        state.mark_search_dirty();
+                    } else if key.code == KeyCode::Char('c')
+                        && key.modifiers.contains(KeyModifiers::CONTROL)
+                    {
+                        // Ctrl+C always quits (not rebindable).
+                        break 'main;
+                    } else if let Some(action) = keybindings.resolve(key.code, key.modifiers) {
+                        // --- Rebindable actions resolved from the keybinding map ---
+                        match action {
+                            KeyAction::Quit => break 'main,
+                            KeyAction::FocusSidebar => {
+                                state.focused_panel = FocusedPanel::Sidebar;
+                                state.show_sidebar = true;
+                                if !matches!(
+                                    state.sidebar_item_at_visible(state.sidebar_selected),
+                                    Some(SidebarItem::File { .. })
+                                ) {
+                                    if let Some(idx) =
+                                        state.sidebar_visible.iter().position(|idx| {
+                                            matches!(
+                                                state.sidebar_items[*idx],
+                                                SidebarItem::File { .. }
+                                            )
+                                        })
+                                    {
+                                        state.sidebar_selected = idx;
+                                    }
                                 }
                             }
-                        }
-                        KeyCode::Char('2') => {
-                            state.focused_panel = FocusedPanel::DiffView;
-                        }
-                        KeyCode::Tab => {
-                            state.show_sidebar = !state.show_sidebar;
-                            if !state.show_sidebar {
+                            KeyAction::FocusDiff => {
                                 state.focused_panel = FocusedPanel::DiffView;
                             }
-                        }
-                        KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            if !state.file_diffs.is_empty() {
-                                let mut next = state.sidebar_selected + 1;
-                                while next < state.sidebar_visible_len() {
-                                    if let Some(SidebarItem::File { file_index, .. }) =
-                                        state.sidebar_item_at_visible(next).cloned()
-                                    {
-                                        state.sidebar_selected = next;
-                                        state.select_file(file_index);
-                                        let visible_height =
-                                            terminal.size()?.height.saturating_sub(5) as usize;
-                                        ensure_sidebar_visible(&mut state, visible_height);
-                                        break;
+                            KeyAction::ToggleSidebar => {
+                                state.show_sidebar = !state.show_sidebar;
+                                if !state.show_sidebar {
+                                    state.focused_panel = FocusedPanel::DiffView;
+                                }
+                            }
+                            KeyAction::NextFile => {
+                                if !state.file_diffs.is_empty() {
+                                    let mut next = state.sidebar_selected + 1;
+                                    while next < state.sidebar_visible_len() {
+                                        if let Some(SidebarItem::File { file_index, .. }) =
+                                            state.sidebar_item_at_visible(next).cloned()
+                                        {
+                                            state.sidebar_selected = next;
+                                            state.select_file(file_index);
+                                            let visible_height =
+                                                terminal.size()?.height.saturating_sub(5) as usize;
+                                            ensure_sidebar_visible(&mut state, visible_height);
+                                            break;
+                                        }
+                                        next += 1;
                                     }
-                                    next += 1;
+                                }
+                            }
+                            KeyAction::PrevFile => {
+                                if !state.file_diffs.is_empty() && state.sidebar_selected > 0 {
+                                    let mut prev = state.sidebar_selected - 1;
+                                    loop {
+                                        if let Some(SidebarItem::File { file_index, .. }) =
+                                            state.sidebar_item_at_visible(prev).cloned()
+                                        {
+                                            state.sidebar_selected = prev;
+                                            state.select_file(file_index);
+                                            ensure_sidebar_visible(&mut state, usize::MAX);
+                                            break;
+                                        }
+                                        if prev == 0 {
+                                            break;
+                                        }
+                                        prev -= 1;
+                                    }
+                                }
+                            }
+                            KeyAction::HalfPageDown => {
+                                let half_screen = (visible_height / 2) as u16;
+                                state.scroll =
+                                    (state.scroll + half_screen).min(max_scroll as u16);
+                            }
+                            KeyAction::HalfPageUp => {
+                                let half_screen = (visible_height / 2) as u16;
+                                state.scroll = state.scroll.saturating_sub(half_screen);
+                            }
+                            KeyAction::NextHunk => {
+                                if !state.file_diffs.is_empty() {
+                                    state.clear_selection();
+                                    let hunks = state.get_hunks().to_vec();
+                                    let current_hunk = state.focused_hunk.unwrap_or(0);
+                                    let next_hunk = if state.focused_hunk.is_none() {
+                                        hunks
+                                            .iter()
+                                            .position(|&h| h > state.scroll as usize + 5)
+                                            .unwrap_or(0)
+                                    } else {
+                                        (current_hunk + 1).min(hunks.len().saturating_sub(1))
+                                    };
+                                    if !hunks.is_empty() {
+                                        state.focused_hunk = Some(next_hunk);
+                                        state.scroll = adjust_scroll_for_hunk(
+                                            hunks[next_hunk],
+                                            state.scroll,
+                                            visible_height,
+                                            max_scroll,
+                                        );
+                                    }
+                                }
+                            }
+                            KeyAction::PrevHunk => {
+                                if !state.file_diffs.is_empty() {
+                                    state.clear_selection();
+                                    let hunks = state.get_hunks().to_vec();
+                                    let current_hunk =
+                                        state.focused_hunk.unwrap_or(hunks.len());
+                                    let prev_hunk = if state.focused_hunk.is_none() {
+                                        hunks
+                                            .iter()
+                                            .rposition(|&h| {
+                                                (h as u16) < state.scroll.saturating_sub(5)
+                                            })
+                                            .unwrap_or(hunks.len().saturating_sub(1))
+                                    } else {
+                                        current_hunk.saturating_sub(1)
+                                    };
+                                    if !hunks.is_empty() {
+                                        state.focused_hunk = Some(prev_hunk);
+                                        state.scroll = adjust_scroll_for_hunk(
+                                            hunks[prev_hunk],
+                                            state.scroll,
+                                            visible_height,
+                                            max_scroll,
+                                        );
+                                    }
+                                }
+                            }
+                            KeyAction::HScrollLeft => {
+                                if state.focused_panel == FocusedPanel::DiffView {
+                                    state.h_scroll = state.h_scroll.saturating_sub(4);
+                                } else if state.focused_panel == FocusedPanel::Sidebar {
+                                    state.sidebar_h_scroll =
+                                        state.sidebar_h_scroll.saturating_sub(4);
+                                }
+                            }
+                            KeyAction::HScrollRight => {
+                                if state.focused_panel == FocusedPanel::DiffView {
+                                    state.h_scroll = state.h_scroll.saturating_add(4);
+                                } else if state.focused_panel == FocusedPanel::Sidebar {
+                                    state.sidebar_h_scroll =
+                                        state.sidebar_h_scroll.saturating_add(4);
                                 }
                             }
                         }
-                        KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            if !state.file_diffs.is_empty() && state.sidebar_selected > 0 {
-                                let mut prev = state.sidebar_selected - 1;
-                                loop {
-                                    if let Some(SidebarItem::File { file_index, .. }) =
-                                        state.sidebar_item_at_visible(prev).cloned()
-                                    {
-                                        state.sidebar_selected = prev;
-                                        state.select_file(file_index);
-                                        ensure_sidebar_visible(&mut state, usize::MAX);
-                                        break;
-                                    }
-                                    if prev == 0 {
-                                        break;
-                                    }
-                                    prev -= 1;
-                                }
-                            }
-                        }
+                    } else {
+                    // --- Fallback: non-rebindable actions handled by match ---
+                    match key.code {
                         // Stacked mode: navigate to next commit
                         KeyCode::Char('l') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                             if state.stacked_mode
@@ -1022,14 +1116,6 @@ fn run_app_internal(
                                 let new_index = state.current_commit_index - 1;
                                 navigate_stacked_commit(&mut state, new_index, &options, backend);
                             }
-                        }
-                        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            let half_screen = (visible_height / 2) as u16;
-                            state.scroll = (state.scroll + half_screen).min(max_scroll as u16);
-                        }
-                        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            let half_screen = (visible_height / 2) as u16;
-                            state.scroll = state.scroll.saturating_sub(half_screen);
                         }
                         KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                             if !state.file_diffs.is_empty() {
@@ -1129,20 +1215,6 @@ fn run_app_internal(
                                 ensure_sidebar_visible(&mut state, usize::MAX);
                             } else {
                                 state.scroll = state.scroll.saturating_sub(1);
-                            }
-                        }
-                        KeyCode::Char('h') | KeyCode::Left => {
-                            if state.focused_panel == FocusedPanel::DiffView {
-                                state.h_scroll = state.h_scroll.saturating_sub(4);
-                            } else if state.focused_panel == FocusedPanel::Sidebar {
-                                state.sidebar_h_scroll = state.sidebar_h_scroll.saturating_sub(4);
-                            }
-                        }
-                        KeyCode::Char('l') | KeyCode::Right => {
-                            if state.focused_panel == FocusedPanel::DiffView {
-                                state.h_scroll = state.h_scroll.saturating_add(4);
-                            } else if state.focused_panel == FocusedPanel::Sidebar {
-                                state.sidebar_h_scroll = state.sidebar_h_scroll.saturating_add(4);
                             }
                         }
                         KeyCode::Enter => {
@@ -1325,54 +1397,6 @@ fn run_app_internal(
                         }
                         KeyCode::PageUp => {
                             state.scroll = state.scroll.saturating_sub(20);
-                        }
-                        KeyCode::Char('}') => {
-                            if !state.file_diffs.is_empty() {
-                                state.clear_selection(); // Clear selection on hunk navigation
-                                let hunks = state.get_hunks().to_vec();
-                                let current_hunk = state.focused_hunk.unwrap_or(0);
-                                let next_hunk = if state.focused_hunk.is_none() {
-                                    hunks
-                                        .iter()
-                                        .position(|&h| h > state.scroll as usize + 5)
-                                        .unwrap_or(0)
-                                } else {
-                                    (current_hunk + 1).min(hunks.len().saturating_sub(1))
-                                };
-                                if !hunks.is_empty() {
-                                    state.focused_hunk = Some(next_hunk);
-                                    state.scroll = adjust_scroll_for_hunk(
-                                        hunks[next_hunk],
-                                        state.scroll,
-                                        visible_height,
-                                        max_scroll,
-                                    );
-                                }
-                            }
-                        }
-                        KeyCode::Char('{') => {
-                            if !state.file_diffs.is_empty() {
-                                state.clear_selection(); // Clear selection on hunk navigation
-                                let hunks = state.get_hunks().to_vec();
-                                let current_hunk = state.focused_hunk.unwrap_or(hunks.len());
-                                let prev_hunk = if state.focused_hunk.is_none() {
-                                    hunks
-                                        .iter()
-                                        .rposition(|&h| (h as u16) < state.scroll.saturating_sub(5))
-                                        .unwrap_or(hunks.len().saturating_sub(1))
-                                } else {
-                                    current_hunk.saturating_sub(1)
-                                };
-                                if !hunks.is_empty() {
-                                    state.focused_hunk = Some(prev_hunk);
-                                    state.scroll = adjust_scroll_for_hunk(
-                                        hunks[prev_hunk],
-                                        state.scroll,
-                                        visible_height,
-                                        max_scroll,
-                                    );
-                                }
-                            }
                         }
                         KeyCode::Char('i') => {
                             if !state.file_diffs.is_empty() {
@@ -1765,6 +1789,7 @@ fn run_app_internal(
                         }
                         _ => {}
                     }
+                    } // close else (fallback match block)
                 }
                 _ => {}
             }

--- a/src/command/diff/git.rs
+++ b/src/command/diff/git.rs
@@ -335,6 +335,7 @@ mod tests {
             theme: None,
             stacked: false,
             focus: None,
+            keybindings: None,
         };
 
         let diffs = load_file_diffs(&options, &backend);

--- a/src/command/diff/keybindings.rs
+++ b/src/command/diff/keybindings.rs
@@ -1,0 +1,390 @@
+use std::collections::HashMap;
+
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Actions that can be rebound by the user via `lumen.config.json`.
+///
+/// Only a curated subset of the TUI key handlers are exposed here.
+/// Everything else (search mode, annotation editor, modals, etc.)
+/// remains hardcoded in the main event loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyAction {
+    FocusSidebar,
+    FocusDiff,
+    ToggleSidebar,
+    HScrollLeft,
+    HScrollRight,
+    NextFile,
+    PrevFile,
+    HalfPageDown,
+    HalfPageUp,
+    NextHunk,
+    PrevHunk,
+    Quit,
+}
+
+/// Maps physical key combinations to logical `KeyAction`s.
+///
+/// Built once at startup from default bindings merged with user overrides.
+/// The `resolve` method is called on every key press (before the fallback
+/// match block) and returns `Some(action)` when a rebindable action matches.
+pub struct KeyBindings {
+    map: HashMap<(KeyCode, KeyModifiers), KeyAction>,
+}
+
+impl KeyBindings {
+    /// Construct the binding map by applying user overrides on top of defaults.
+    ///
+    /// # Arguments
+    ///
+    /// * `overrides` - Optional map from action name (e.g. `"focus_sidebar"`) to
+    ///   key string (e.g. `"Left"`, `"Shift+Right"`, `"Ctrl+j"`).
+    pub fn new(overrides: Option<&HashMap<String, String>>) -> Self {
+        let mut map: HashMap<(KeyCode, KeyModifiers), KeyAction> = HashMap::new();
+
+        // Defaults: each action can be bound to multiple keys.
+        let defaults: Vec<(KeyAction, Vec<(KeyCode, KeyModifiers)>)> = vec![
+            (
+                KeyAction::FocusSidebar,
+                vec![(KeyCode::Char('1'), KeyModifiers::NONE)],
+            ),
+            (
+                KeyAction::FocusDiff,
+                vec![(KeyCode::Char('2'), KeyModifiers::NONE)],
+            ),
+            (
+                KeyAction::ToggleSidebar,
+                vec![(KeyCode::Tab, KeyModifiers::NONE)],
+            ),
+            (
+                KeyAction::HScrollLeft,
+                vec![
+                    (KeyCode::Char('h'), KeyModifiers::NONE),
+                    (KeyCode::Left, KeyModifiers::NONE),
+                ],
+            ),
+            (
+                KeyAction::HScrollRight,
+                vec![
+                    (KeyCode::Char('l'), KeyModifiers::NONE),
+                    (KeyCode::Right, KeyModifiers::NONE),
+                ],
+            ),
+            (
+                KeyAction::NextFile,
+                vec![(KeyCode::Char('j'), KeyModifiers::CONTROL)],
+            ),
+            (
+                KeyAction::PrevFile,
+                vec![(KeyCode::Char('k'), KeyModifiers::CONTROL)],
+            ),
+            (
+                KeyAction::HalfPageDown,
+                vec![(KeyCode::Char('d'), KeyModifiers::CONTROL)],
+            ),
+            (
+                KeyAction::HalfPageUp,
+                vec![(KeyCode::Char('u'), KeyModifiers::CONTROL)],
+            ),
+            (
+                KeyAction::NextHunk,
+                vec![(KeyCode::Char('}'), KeyModifiers::NONE)],
+            ),
+            (
+                KeyAction::PrevHunk,
+                vec![(KeyCode::Char('{'), KeyModifiers::NONE)],
+            ),
+            (
+                KeyAction::Quit,
+                vec![
+                    (KeyCode::Char('q'), KeyModifiers::NONE),
+                    (KeyCode::Esc, KeyModifiers::NONE),
+                ],
+            ),
+        ];
+
+        // Collect overridden actions so we can skip their defaults.
+        let overridden_actions: HashMap<KeyAction, Vec<(KeyCode, KeyModifiers)>> =
+            if let Some(user_map) = overrides {
+                let mut result: HashMap<KeyAction, Vec<(KeyCode, KeyModifiers)>> = HashMap::new();
+                for (action_str, key_str) in user_map {
+                    if let Some(action) = parse_action_name(action_str) {
+                        if let Some(combo) = parse_key_string(key_str) {
+                            result.entry(action).or_default().push(combo);
+                        }
+                    }
+                }
+                result
+            } else {
+                HashMap::new()
+            };
+
+        // Insert defaults, skipping any action that has user overrides.
+        for (action, combos) in &defaults {
+            if !overridden_actions.contains_key(action) {
+                for &combo in combos {
+                    map.insert(combo, *action);
+                }
+            }
+        }
+
+        // Insert user overrides (possibly replacing default combos from other actions).
+        for (action, combos) in &overridden_actions {
+            for &combo in combos {
+                map.insert(combo, *action);
+            }
+        }
+
+        Self { map }
+    }
+
+    /// Look up the action bound to the given key code and modifiers.
+    ///
+    /// Returns `None` if no rebindable action is mapped to this combination,
+    /// meaning the caller should fall through to the hardcoded match block.
+    pub fn resolve(&self, code: KeyCode, modifiers: KeyModifiers) -> Option<KeyAction> {
+        self.map.get(&(code, modifiers)).copied()
+    }
+}
+
+/// Parse a user-facing action name string into the corresponding enum variant.
+///
+/// Returns `None` for unrecognized names (silently ignored).
+fn parse_action_name(name: &str) -> Option<KeyAction> {
+    match name {
+        "focus_sidebar" => Some(KeyAction::FocusSidebar),
+        "focus_diff" => Some(KeyAction::FocusDiff),
+        "toggle_sidebar" => Some(KeyAction::ToggleSidebar),
+        "h_scroll_left" => Some(KeyAction::HScrollLeft),
+        "h_scroll_right" => Some(KeyAction::HScrollRight),
+        "next_file" => Some(KeyAction::NextFile),
+        "prev_file" => Some(KeyAction::PrevFile),
+        "half_page_down" => Some(KeyAction::HalfPageDown),
+        "half_page_up" => Some(KeyAction::HalfPageUp),
+        "next_hunk" => Some(KeyAction::NextHunk),
+        "prev_hunk" => Some(KeyAction::PrevHunk),
+        "quit" => Some(KeyAction::Quit),
+        _ => None,
+    }
+}
+
+/// Parse a key string like `"Ctrl+j"`, `"Shift+Left"`, `"Tab"`, `"q"`, `"}"` into
+/// a `(KeyCode, KeyModifiers)` tuple.
+///
+/// Supported modifier prefixes (case-insensitive, combinable with `+`):
+/// - `Ctrl`
+/// - `Shift`
+/// - `Alt`
+///
+/// Supported key names (case-insensitive for named keys):
+/// - `Left`, `Right`, `Up`, `Down`
+/// - `Tab`, `Enter`, `Esc`, `Space`
+/// - `PageUp`, `PageDown`, `Home`, `End`
+/// - `Backspace`, `Delete`
+/// - Single characters: `a`-`z`, `0`-`9`, punctuation
+///
+/// # Returns
+///
+/// `None` if the string cannot be parsed.
+fn parse_key_string(s: &str) -> Option<(KeyCode, KeyModifiers)> {
+    let parts: Vec<&str> = s.split('+').collect();
+    let mut modifiers = KeyModifiers::NONE;
+
+    // All parts except the last are modifiers.
+    for &part in &parts[..parts.len() - 1] {
+        match part.to_lowercase().as_str() {
+            "ctrl" => modifiers |= KeyModifiers::CONTROL,
+            "shift" => modifiers |= KeyModifiers::SHIFT,
+            "alt" => modifiers |= KeyModifiers::ALT,
+            _ => return None,
+        }
+    }
+
+    let key_part = parts.last()?;
+    let code = parse_key_code(key_part)?;
+
+    Some((code, modifiers))
+}
+
+/// Parse the key name portion (after modifiers) into a `KeyCode`.
+fn parse_key_code(s: &str) -> Option<KeyCode> {
+    // Named keys (case-insensitive).
+    match s.to_lowercase().as_str() {
+        "left" => return Some(KeyCode::Left),
+        "right" => return Some(KeyCode::Right),
+        "up" => return Some(KeyCode::Up),
+        "down" => return Some(KeyCode::Down),
+        "tab" => return Some(KeyCode::Tab),
+        "enter" => return Some(KeyCode::Enter),
+        "esc" | "escape" => return Some(KeyCode::Esc),
+        "space" => return Some(KeyCode::Char(' ')),
+        "pageup" => return Some(KeyCode::PageUp),
+        "pagedown" => return Some(KeyCode::PageDown),
+        "home" => return Some(KeyCode::Home),
+        "end" => return Some(KeyCode::End),
+        "backspace" => return Some(KeyCode::Backspace),
+        "delete" => return Some(KeyCode::Delete),
+        _ => {}
+    }
+
+    // Single character (preserves case for char matching).
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() == 1 {
+        return Some(KeyCode::Char(chars[0]));
+    }
+
+    // Function keys: F1-F12.
+    if s.len() >= 2 && (s.starts_with('F') || s.starts_with('f')) {
+        if let Ok(n) = s[1..].parse::<u8>() {
+            if (1..=12).contains(&n) {
+                return Some(KeyCode::F(n));
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_key_string_simple_char() {
+        assert_eq!(
+            parse_key_string("q"),
+            Some((KeyCode::Char('q'), KeyModifiers::NONE))
+        );
+    }
+
+    #[test]
+    fn test_parse_key_string_ctrl_modifier() {
+        assert_eq!(
+            parse_key_string("Ctrl+j"),
+            Some((KeyCode::Char('j'), KeyModifiers::CONTROL))
+        );
+    }
+
+    #[test]
+    fn test_parse_key_string_shift_modifier() {
+        assert_eq!(
+            parse_key_string("Shift+Left"),
+            Some((KeyCode::Left, KeyModifiers::SHIFT))
+        );
+    }
+
+    #[test]
+    fn test_parse_key_string_named_key() {
+        assert_eq!(
+            parse_key_string("Tab"),
+            Some((KeyCode::Tab, KeyModifiers::NONE))
+        );
+        assert_eq!(
+            parse_key_string("Esc"),
+            Some((KeyCode::Esc, KeyModifiers::NONE))
+        );
+        assert_eq!(
+            parse_key_string("Left"),
+            Some((KeyCode::Left, KeyModifiers::NONE))
+        );
+    }
+
+    #[test]
+    fn test_parse_key_string_punctuation() {
+        assert_eq!(
+            parse_key_string("}"),
+            Some((KeyCode::Char('}'), KeyModifiers::NONE))
+        );
+        assert_eq!(
+            parse_key_string("{"),
+            Some((KeyCode::Char('{'), KeyModifiers::NONE))
+        );
+    }
+
+    #[test]
+    fn test_parse_key_string_multiple_modifiers() {
+        assert_eq!(
+            parse_key_string("Ctrl+Shift+Left"),
+            Some((KeyCode::Left, KeyModifiers::CONTROL | KeyModifiers::SHIFT))
+        );
+    }
+
+    #[test]
+    fn test_parse_action_name_valid() {
+        assert_eq!(parse_action_name("focus_sidebar"), Some(KeyAction::FocusSidebar));
+        assert_eq!(parse_action_name("quit"), Some(KeyAction::Quit));
+    }
+
+    #[test]
+    fn test_parse_action_name_invalid() {
+        assert_eq!(parse_action_name("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_keybindings_defaults() {
+        let kb = KeyBindings::new(None);
+        assert_eq!(
+            kb.resolve(KeyCode::Char('1'), KeyModifiers::NONE),
+            Some(KeyAction::FocusSidebar)
+        );
+        assert_eq!(
+            kb.resolve(KeyCode::Char('q'), KeyModifiers::NONE),
+            Some(KeyAction::Quit)
+        );
+        assert_eq!(
+            kb.resolve(KeyCode::Esc, KeyModifiers::NONE),
+            Some(KeyAction::Quit)
+        );
+    }
+
+    #[test]
+    fn test_keybindings_override_removes_old_default() {
+        // Override focus_sidebar from '1' to 'Left'
+        let mut overrides = HashMap::new();
+        overrides.insert("focus_sidebar".to_string(), "Left".to_string());
+        let kb = KeyBindings::new(Some(&overrides));
+
+        // New binding works
+        assert_eq!(
+            kb.resolve(KeyCode::Left, KeyModifiers::NONE),
+            Some(KeyAction::FocusSidebar)
+        );
+        // Old default '1' is no longer bound to FocusSidebar
+        assert_eq!(kb.resolve(KeyCode::Char('1'), KeyModifiers::NONE), None);
+    }
+
+    #[test]
+    fn test_keybindings_override_replaces_conflicting_default() {
+        // Override focus_sidebar to 'Left', which was previously h_scroll_left
+        let mut overrides = HashMap::new();
+        overrides.insert("focus_sidebar".to_string(), "Left".to_string());
+        let kb = KeyBindings::new(Some(&overrides));
+
+        // Left is now focus_sidebar, not h_scroll_left
+        assert_eq!(
+            kb.resolve(KeyCode::Left, KeyModifiers::NONE),
+            Some(KeyAction::FocusSidebar)
+        );
+        // 'h' still maps to h_scroll_left (unaffected)
+        assert_eq!(
+            kb.resolve(KeyCode::Char('h'), KeyModifiers::NONE),
+            Some(KeyAction::HScrollLeft)
+        );
+    }
+
+    #[test]
+    fn test_parse_key_string_space() {
+        assert_eq!(
+            parse_key_string("Space"),
+            Some((KeyCode::Char(' '), KeyModifiers::NONE))
+        );
+    }
+
+    #[test]
+    fn test_parse_key_string_digit() {
+        assert_eq!(
+            parse_key_string("1"),
+            Some((KeyCode::Char('1'), KeyModifiers::NONE))
+        );
+    }
+}

--- a/src/command/diff/mod.rs
+++ b/src/command/diff/mod.rs
@@ -5,6 +5,7 @@ mod coordinates;
 mod diff_algo;
 pub mod git;
 pub mod highlight;
+mod keybindings;
 mod render;
 mod search;
 mod state;
@@ -13,7 +14,7 @@ pub mod theme;
 mod types;
 mod watcher;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::process::{self, Command};
 use std::thread;
@@ -31,6 +32,8 @@ pub struct DiffOptions {
     pub theme: Option<String>,
     pub stacked: bool,
     pub focus: Option<String>,
+    /// User-provided keybinding overrides from `lumen.config.json`.
+    pub keybindings: Option<HashMap<String, String>>,
 }
 
 #[derive(Clone)]

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -29,6 +29,13 @@ pub struct LumenConfig {
 
     #[serde(default)]
     pub theme: Option<String>,
+
+    /// Optional keybinding overrides for the diff TUI.
+    ///
+    /// Keys are action names (e.g. `"focus_sidebar"`, `"quit"`).
+    /// Values are key strings (e.g. `"Left"`, `"Ctrl+j"`, `"Shift+Right"`).
+    #[serde(default)]
+    pub keybindings: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -126,6 +133,7 @@ impl LumenConfig {
             api_key,
             draft: config.draft,
             theme: config.theme,
+            keybindings: config.keybindings,
         })
     }
 
@@ -151,6 +159,7 @@ impl Default for LumenConfig {
             api_key: default_api_key(),
             draft: default_draft_config(),
             theme: None,
+            keybindings: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ async fn run() -> Result<(), LumenError> {
                 theme: theme.or(config.theme.clone()),
                 stacked,
                 focus,
+                keybindings: config.keybindings.clone(),
             };
             command::diff::run_diff_ui(options, backend.as_ref())?;
         }


### PR DESCRIPTION
I tested this in my local fork; fixes #141

- Adds optional `keybindings` field to `lumen.config.json` allowing users to override default key mappings for the diff TUI
- Overrides are resolved before the default match block, so unconfigured keys retain existing behavior
- Supports modifier combinations (`Ctrl+`, `Shift+`) and special keys (`Left`, `Right`, `Tab`, `Esc`, etc.)
- 12 rebindable actions: `focus_sidebar`, `focus_diff`, `toggle_sidebar`, `h_scroll_left`, `h_scroll_right`, `next_file`, `prev_file`, `half_page_down`, `half_page_up`, `next_hunk`, `prev_hunk`, `quit`

Example config (`~/.config/lumen/lumen.config.json`):
```json
{
  "keybindings": {
    "focus_sidebar": "Left",
    "focus_diff": "Right",
    "h_scroll_left": "Shift+Left",
    "h_scroll_right": "Shift+Right"
  }
}
```