### PR TITLE
feat(ai): add OpenCode Go provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ export LUMEN_AI_MODEL="gpt-5-mini"
 | [DeepSeek](https://www.deepseek.com/) `deepseek` | Yes | `deepseek-chat` (V3.2), `deepseek-reasoner` (default: `deepseek-chat`) |
 | [xAI](https://x.ai/) `xai` | Yes | `grok-4`, `grok-4-mini`, `grok-4-mini-fast` (default: `grok-4-mini-fast`) |
 | [OpenCode Zen](https://opencode.ai/docs/zen) `opencode-zen` | Yes | [see list](https://opencode.ai/docs/zen#models) (default: `claude-sonnet-4-5`) |
+| [OpenCode Go](https://dev.opencode.ai/docs/go/) `opencode-go` | Yes | `glm-5.1`, `glm-5`, `kimi-k2.5`, `kimi-k2.6`, `deepseek-v4-pro`, `deepseek-v4-flash`, `mimo-v2.5`, `mimo-v2.5-pro`, `qwen3.6-plus`, `qwen3.5-plus` (default: `kimi-k2.6`) |
 | [Ollama](https://github.com/ollama/ollama) `ollama` | No (local) | [see list](https://ollama.com/library) (default: `llama3.2`) |
 | [OpenRouter](https://openrouter.ai/) `openrouter` | Yes | [see list](https://openrouter.ai/models) (default: `anthropic/claude-sonnet-4.5`) |
 | [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) `vercel` | Yes | [see list](https://vercel.com/docs/ai-gateway/supported-models) (default: `anthropic/claude-sonnet-4.5`) |

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -45,6 +45,7 @@ pub enum ProviderType {
     Claude,
     Ollama,
     OpencodeZen,
+    OpencodeGo,
     Openrouter,
     Deepseek,
     Gemini,
@@ -62,6 +63,7 @@ impl FromStr for ProviderType {
             "claude" => Ok(ProviderType::Claude),
             "ollama" => Ok(ProviderType::Ollama),
             "opencode-zen" => Ok(ProviderType::OpencodeZen),
+            "opencode-go" => Ok(ProviderType::OpencodeGo),
             "openrouter" => Ok(ProviderType::Openrouter),
             "deepseek" => Ok(ProviderType::Deepseek),
             "gemini" => Ok(ProviderType::Gemini),
@@ -164,5 +166,21 @@ mod tests {
     fn test_vcs_not_specified() {
         let cli = Cli::try_parse_from(["lumen", "diff"]).unwrap();
         assert_eq!(cli.vcs, None);
+    }
+
+    #[test]
+    fn test_opencode_go_provider_parses() {
+        let cli = Cli::try_parse_from([
+            "lumen",
+            "--provider",
+            "opencode-go",
+            "--model",
+            "kimi-k2.6",
+            "draft",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.provider, Some(ProviderType::OpencodeGo));
+        assert_eq!(cli.model, Some("kimi-k2.6".to_string()));
     }
 }

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -53,6 +53,13 @@ pub const ALL_PROVIDERS: &[ProviderInfo] = &[
         env_key: "OPENCODE_API_KEY",
     },
     ProviderInfo {
+        id: "opencode-go",
+        provider_type: ProviderType::OpencodeGo,
+        display_name: "OpenCode Go",
+        default_model: "kimi-k2.6",
+        env_key: "OPENCODE_API_KEY",
+    },
+    ProviderInfo {
         id: "openrouter",
         provider_type: ProviderType::Openrouter,
         display_name: "OpenRouter",

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -34,7 +34,7 @@ pub struct LumenProvider {
     provider_name: String,
 }
 
-/// Provider configuration for custom endpoint providers (OpenCode Zen, OpenRouter, Vercel)
+/// Provider configuration for custom endpoint providers (OpenCode Zen, OpenCode Go, OpenRouter, Vercel)
 struct CustomProviderConfig {
     endpoint: &'static str,
     env_key: &'static str,
@@ -48,12 +48,20 @@ impl LumenProvider {
         model: Option<String>,
     ) -> Result<Self, LumenError> {
         let (backend, provider_name) = match provider_type {
-            // Custom endpoint providers (OpenCode Zen, OpenRouter, Vercel) - use ServiceTargetResolver
-            ProviderType::OpencodeZen | ProviderType::Openrouter | ProviderType::Vercel => {
+            // Custom endpoint providers (OpenCode Zen, OpenCode Go, OpenRouter, Vercel) - use ServiceTargetResolver
+            ProviderType::OpencodeZen
+            | ProviderType::OpencodeGo
+            | ProviderType::Openrouter
+            | ProviderType::Vercel => {
                 let defaults = ProviderInfo::for_provider(provider_type);
                 let config = match provider_type {
                     ProviderType::OpencodeZen => CustomProviderConfig {
                         endpoint: "https://opencode.ai/zen/v1/",
+                        env_key: defaults.env_key,
+                        adapter_kind: AdapterKind::OpenAI,
+                    },
+                    ProviderType::OpencodeGo => CustomProviderConfig {
+                        endpoint: "https://opencode.ai/zen/go/v1/",
                         env_key: defaults.env_key,
                         adapter_kind: AdapterKind::OpenAI,
                     },

--- a/src/vcs/test_utils.rs
+++ b/src/vcs/test_utils.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use git2::{Repository, Signature};
+use git2::{Repository, RepositoryInitOptions, Signature};
 
 /// Global lock for tests that change the current working directory.
 /// Prevents concurrent tests from interfering with each other.
@@ -40,7 +40,9 @@ pub fn git(dir: &Path, args: &[&str]) {
 
     match args[0] {
         "init" => {
-            Repository::init(dir).expect("failed to init repo");
+            let mut opts = RepositoryInitOptions::new();
+            opts.initial_head("main");
+            Repository::init_opts(dir, &opts).expect("failed to init repo");
         }
         "config" if args.len() >= 3 => {
             let repo = Repository::open(dir).expect("failed to open repo");
@@ -155,7 +157,9 @@ impl RepoGuard {
         let dir = make_temp_dir("lumen-test");
 
         // Initialize repo with git2
-        let repo = Repository::init(&dir).expect("failed to init repo");
+        let mut opts = RepositoryInitOptions::new();
+        opts.initial_head("main");
+        let repo = Repository::init_opts(&dir, &opts).expect("failed to init repo");
 
         // Set config
         let mut config = repo.config().expect("failed to get config");


### PR DESCRIPTION
## Summary
- add `opencode-go` as a supported AI provider
- route OpenCode Go to the OpenAI-compatible `https://opencode.ai/zen/go/v1/` endpoint
- document Go model IDs and add CLI parsing coverage
- initialize git test repos with `main` so merge-base tests are deterministic

## Tests
- `cargo check`
- `cargo test` (127 passed)
- `cargo run -- --provider opencode-go --model kimi-k2.6 draft --help`
- `cargo run -- --provider opencode-go diff --help`