### PR TITLE
Inline annotation editor with click-to-edit

### DIFF
--- a/src/command/diff/annotation.rs
+++ b/src/command/diff/annotation.rs
@@ -3,13 +3,12 @@ use std::time::SystemTime;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Clear, Paragraph},
 };
 use tui_textarea::TextArea;
 
 use super::state::AnnotationTarget;
 use super::theme;
-use crate::command::diff::types::DiffPanelFocus;
 
 /// Result of handling input in the annotation editor
 pub enum AnnotationEditorResult {
@@ -23,7 +22,11 @@ pub enum AnnotationEditorResult {
     Delete,
 }
 
-/// A modal editor for creating/editing annotations
+const MIN_INNER_LINES: usize = 3;
+
+/// Inline annotation editor: a bordered textbox rendered in the same slot
+/// where the saved annotation overlay would live (below a line range, or
+/// at the top of the file for file-level annotations).
 pub struct AnnotationEditor<'a> {
     textarea: TextArea<'a>,
     pub filename: String,
@@ -42,7 +45,6 @@ impl<'a> AnnotationEditor<'a> {
 
         textarea.set_cursor_line_style(Style::default());
         textarea.set_cursor_style(Style::default().bg(t.ui.text_primary).fg(t.ui.bg));
-        textarea.set_block(Block::default());
 
         Self {
             textarea,
@@ -63,7 +65,6 @@ impl<'a> AnnotationEditor<'a> {
         let t = theme::get();
         self.textarea.set_cursor_line_style(Style::default());
         self.textarea.set_cursor_style(Style::default().bg(t.ui.text_primary).fg(t.ui.bg));
-        self.textarea.set_block(Block::default());
 
         self.textarea.move_cursor(tui_textarea::CursorMove::Bottom);
         self.textarea.move_cursor(tui_textarea::CursorMove::End);
@@ -71,17 +72,25 @@ impl<'a> AnnotationEditor<'a> {
         self
     }
 
-    /// Get the annotation content
     pub fn content(&self) -> String {
         self.textarea.lines().join("\n")
     }
 
-    /// Get the creation time (original if editing, now if new)
+    pub fn is_empty(&self) -> bool {
+        self.content().trim().is_empty()
+    }
+
     pub fn created_at(&self) -> SystemTime {
         self.original_created_at.unwrap_or_else(SystemTime::now)
     }
 
-    /// Handle a key event. Returns the result of the input handling.
+    /// Rows the editor wants to occupy: top + bottom borders, content padded to
+    /// `MIN_INNER_LINES`, plus a dim hint row floating below the box.
+    pub fn desired_height(&self) -> usize {
+        let content_lines = self.textarea.lines().len().max(1);
+        content_lines.max(MIN_INNER_LINES) + 2 + 1
+    }
+
     pub fn handle_input(&mut self, key: KeyEvent) -> AnnotationEditorResult {
         match key.code {
             KeyCode::Esc => AnnotationEditorResult::Cancel,
@@ -91,8 +100,7 @@ impl<'a> AnnotationEditor<'a> {
             }
 
             KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                let content = self.textarea.lines().join("\n");
-                if content.trim().is_empty() {
+                if self.is_empty() {
                     if self.is_edit {
                         AnnotationEditorResult::Delete
                     } else {
@@ -104,20 +112,20 @@ impl<'a> AnnotationEditor<'a> {
             }
 
             KeyCode::Enter => {
-                if key.modifiers.intersects(KeyModifiers::SHIFT | KeyModifiers::ALT | KeyModifiers::CONTROL) {
+                if key
+                    .modifiers
+                    .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT | KeyModifiers::CONTROL)
+                {
                     self.textarea.insert_char('\n');
                     AnnotationEditorResult::Continue
-                } else {
-                    let content = self.textarea.lines().join("\n");
-                    if content.trim().is_empty() {
-                        if self.is_edit {
-                            AnnotationEditorResult::Delete
-                        } else {
-                            AnnotationEditorResult::Cancel
-                        }
+                } else if self.is_empty() {
+                    if self.is_edit {
+                        AnnotationEditorResult::Delete
                     } else {
-                        AnnotationEditorResult::Save
+                        AnnotationEditorResult::Cancel
                     }
+                } else {
+                    AnnotationEditorResult::Save
                 }
             }
 
@@ -143,72 +151,117 @@ impl<'a> AnnotationEditor<'a> {
         }
     }
 
-    /// Render the annotation editor as a centered modal
-    pub fn render(&self, frame: &mut Frame) {
+    /// Render the editor as an overlay at `area`. `accent` is the border color,
+    /// `bg` the panel background. When `has_gutter` is true a `▍` indicator is
+    /// painted on the leftmost column (matches saved line-range overlays).
+    ///
+    /// The box itself takes `area.height - 1` rows; the final row is a dim
+    /// `enter save · esc cancel` hint floating below the box.
+    pub fn render_inline(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        accent: Color,
+        bg: Color,
+        has_gutter: bool,
+    ) {
+        if area.height < 4 || area.width < 5 {
+            return;
+        }
+
         let t = theme::get();
-        let area = frame.area();
+        let border_style = Style::default().fg(accent);
+        let indicator_style = Style::default().fg(accent);
+        let row_bg = Style::default().bg(bg);
 
-        let width = 60.min(area.width.saturating_sub(4));
-        let height = 10.min(area.height.saturating_sub(4));
-        let x = (area.width.saturating_sub(width)) / 2;
-        let y = (area.height.saturating_sub(height)) / 2;
-        let modal_area = Rect::new(x, y, width, height);
+        frame.render_widget(Clear, area);
 
-        frame.render_widget(Clear, modal_area);
+        // The bordered box occupies all rows except the last (which is the hint).
+        let box_height = area.height - 1;
+        let border_width = area.width.saturating_sub(3) as usize;
 
-        let short_filename = self
-            .filename
-            .rsplit('/')
-            .next()
-            .unwrap_or(&self.filename);
-
-        let title = match &self.target {
-            AnnotationTarget::File => format!(" {} [file] ", short_filename),
-            AnnotationTarget::LineRange { panel, start_line, end_line, .. } => {
-                let panel_label = match panel {
-                    DiffPanelFocus::Old => "old",
-                    DiffPanelFocus::New | DiffPanelFocus::None => "new",
-                };
-                if start_line == end_line {
-                    format!(" {} · L{} [{}] ", short_filename, start_line, panel_label)
-                } else {
-                    format!(" {} · L{}-{} [{}] ", short_filename, start_line, end_line, panel_label)
-                }
-            }
+        // Top border
+        let top = if has_gutter {
+            Line::from(vec![
+                Span::styled("▍", indicator_style),
+                Span::styled(format!("┌{}┐", "─".repeat(border_width)), border_style),
+            ])
+        } else {
+            Line::from(vec![Span::styled(
+                format!(" ┌{}┐", "─".repeat(border_width)),
+                border_style,
+            )])
         };
+        frame.render_widget(
+            Paragraph::new(top).style(row_bg),
+            Rect::new(area.x, area.y, area.width, 1),
+        );
 
-        let block = Block::default()
-            .title(title)
-            .title_style(Style::default().fg(t.ui.text_secondary))
-            .borders(Borders::ALL)
-            .border_type(ratatui::widgets::BorderType::Rounded)
-            .border_style(Style::default().fg(t.ui.border_focused))
-            .style(Style::default().bg(t.ui.bg));
+        // Middle rows: gutter + left bar + (textarea) + right bar
+        let middle_rows = box_height.saturating_sub(2);
+        for row in 0..middle_rows {
+            let y = area.y + 1 + row;
+            let prefix = if has_gutter {
+                Line::from(vec![
+                    Span::styled("▍", indicator_style),
+                    Span::styled("│ ", border_style),
+                ])
+            } else {
+                Line::from(vec![Span::styled(" │ ", border_style)])
+            };
+            frame.render_widget(
+                Paragraph::new(prefix).style(row_bg),
+                Rect::new(area.x, y, 3, 1),
+            );
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled("│", border_style))).style(row_bg),
+                Rect::new(area.x + area.width - 1, y, 1, 1),
+            );
+        }
 
-        let inner = block.inner(modal_area);
-        frame.render_widget(block, modal_area);
+        // Textarea inside the inner area (after gutter + left bar + space)
+        let inner_w = area.width.saturating_sub(4);
+        let inner_h = middle_rows;
+        if inner_w > 0 && inner_h > 0 {
+            let inner = Rect::new(area.x + 3, area.y + 1, inner_w, inner_h);
+            frame.render_widget(Clear, inner);
+            frame.render_widget(Paragraph::new("").style(row_bg), inner);
+            frame.render_widget(&self.textarea, inner);
+        }
 
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Min(1), Constraint::Length(1)])
-            .split(inner);
+        // Clean bottom border
+        let bottom = if has_gutter {
+            Line::from(vec![
+                Span::styled("▍", indicator_style),
+                Span::styled(format!("└{}┘", "─".repeat(border_width)), border_style),
+            ])
+        } else {
+            Line::from(vec![Span::styled(
+                format!(" └{}┘", "─".repeat(border_width)),
+                border_style,
+            )])
+        };
+        frame.render_widget(
+            Paragraph::new(bottom).style(row_bg),
+            Rect::new(area.x, area.y + box_height - 1, area.width, 1),
+        );
 
-        frame.render_widget(&self.textarea, chunks[0]);
-
-        let footer_text = Line::from(vec![
-            Span::styled("enter", Style::default().fg(t.ui.text_muted)),
-            Span::styled(" save  ", Style::default().fg(t.ui.text_muted)),
-            Span::styled("│  ", Style::default().fg(t.ui.border_unfocused)),
-            Span::styled("esc", Style::default().fg(t.ui.text_muted)),
-            Span::styled(" cancel  ", Style::default().fg(t.ui.text_muted)),
-            Span::styled("│  ", Style::default().fg(t.ui.border_unfocused)),
-            Span::styled("shift+enter", Style::default().fg(t.ui.text_muted)),
-            Span::styled(" newline", Style::default().fg(t.ui.text_muted)),
-        ]);
-
-        let footer = Paragraph::new(footer_text)
-            .style(Style::default().bg(t.ui.bg))
-            .alignment(Alignment::Center);
-        frame.render_widget(footer, chunks[1]);
+        // Hint row floating below the box, right-aligned with a soft tone.
+        let key_style = Style::default().fg(t.ui.text_secondary);
+        let label_style = Style::default().fg(t.ui.border_unfocused);
+        let sep_style = Style::default().fg(t.ui.border_unfocused);
+        let hint_spans = vec![
+            Span::styled("Enter", key_style),
+            Span::styled(" save", label_style),
+            Span::styled(" . ", sep_style),
+            Span::styled("Esc", key_style),
+            Span::styled(" cancel", label_style),
+            Span::styled(" ", row_bg),
+        ];
+        let hint = Line::from(hint_spans).alignment(Alignment::Right);
+        frame.render_widget(
+            Paragraph::new(hint).style(row_bg),
+            Rect::new(area.x, area.y + area.height - 1, area.width, 1),
+        );
     }
 }

--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 use crossterm::{
     event::{
         self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
-        MouseEventKind,
+        KeyboardEnhancementFlags, MouseEventKind, PopKeyboardEnhancementFlags,
+        PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -352,6 +353,14 @@ fn run_app_internal(
     enable_raw_mode()?;
     let mut tui_writer = open_tui_writer()?;
     execute!(tui_writer, EnterAlternateScreen, EnableMouseCapture)?;
+    // Opt into the kitty keyboard protocol so terminals that support it
+    // (iTerm2 ≥3.5, kitty, wezterm, alacritty) deliver disambiguated key
+    // events — Shift+Enter as KeyCode::Enter+SHIFT, etc. Older terminals
+    // ignore this sequence silently, so we tolerate failure.
+    let _ = execute!(
+        tui_writer,
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+    );
 
     let mut terminal = Terminal::new(CrosstermBackend::new(tui_writer))?;
 
@@ -433,8 +442,10 @@ fn run_app_internal(
                 .unwrap_or(&branch_fallback);
             let row_offset = std::cell::Cell::new(0usize);
             let gaps_cell = std::cell::RefCell::new(Vec::new());
+            let rects_cell = std::cell::RefCell::new(Vec::new());
+            let editor_rect_cell: std::cell::Cell<Option<ratatui::layout::Rect>> = std::cell::Cell::new(None);
             terminal.draw(|frame| {
-                let (offset, gaps) = render_diff(
+                let (offset, gaps, rects, er) = render_diff(
                     frame,
                     diff,
                     &state.file_diffs,
@@ -472,8 +483,11 @@ fn run_app_internal(
                     viewed_hunks_for_file,
                     state.total_added,
                     state.total_removed,
+                    annotation_editor.as_ref(),
                 );
                 row_offset.set(offset);
+                *rects_cell.borrow_mut() = rects;
+                editor_rect_cell.set(er);
 
                 // Selection action tooltip (shown after drag completes)
                 if state.show_selection_tooltip
@@ -552,16 +566,16 @@ fn run_app_internal(
                 }
 
                 *gaps_cell.borrow_mut() = gaps;
-                // Render annotation editor (on top of everything except modal)
-                if let Some(ref editor) = annotation_editor {
-                    editor.render(frame);
-                }
+                // Editor is rendered inline by render_diff above; only the modal
+                // (annotations list, file picker, etc.) sits on top of everything.
                 if let Some(ref modal) = active_modal {
                     modal.render(frame);
                 }
             })?;
             state.content_row_offset = row_offset.get();
             state.annotation_overlay_gaps = gaps_cell.into_inner();
+            state.annotation_rects = rects_cell.into_inner();
+            state.editor_rect = editor_rect_cell.get();
         }
 
         // Poll for new events if no pending events
@@ -790,6 +804,66 @@ fn run_app_internal(
 
                     match mouse.kind {
                         MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
+                            // Inline annotation editor: click-outside saves (or cancels if empty).
+                            // Click-inside is ignored (textarea cursor placement could be wired later).
+                            if annotation_editor.is_some() {
+                                let inside = state
+                                    .editor_rect
+                                    .map(|r| {
+                                        mouse.column >= r.x
+                                            && mouse.column < r.x + r.width
+                                            && mouse.row >= r.y
+                                            && mouse.row < r.y + r.height
+                                    })
+                                    .unwrap_or(false);
+                                if !inside {
+                                    if let Some(editor) = annotation_editor.as_ref() {
+                                        if editor.is_empty() {
+                                            if let Some(id) = editor.id {
+                                                state.remove_annotation(id);
+                                            }
+                                        } else {
+                                            let content = editor.content();
+                                            if let Some(id) = editor.id {
+                                                state.update_annotation(id, content);
+                                            } else {
+                                                state.add_annotation(
+                                                    editor.filename.clone(),
+                                                    editor.target.clone(),
+                                                    content,
+                                                    editor.created_at(),
+                                                );
+                                            }
+                                        }
+                                    }
+                                    annotation_editor = None;
+                                }
+                                continue;
+                            }
+                            // Click on an existing annotation overlay → open inline editor for it.
+                            let hit_annotation =
+                                state.annotation_rects.iter().find_map(|(id, r)| {
+                                    if mouse.column >= r.x
+                                        && mouse.column < r.x + r.width
+                                        && mouse.row >= r.y
+                                        && mouse.row < r.y + r.height
+                                    {
+                                        Some(*id)
+                                    } else {
+                                        None
+                                    }
+                                });
+                            if let Some(id) = hit_annotation {
+                                if let Some(ann) = state.get_annotation_by_id(id) {
+                                    let new_editor = AnnotationEditor::new(
+                                        ann.filename.clone(),
+                                        ann.target.clone(),
+                                    )
+                                    .with_existing(ann.id, &ann.content, ann.created_at);
+                                    annotation_editor = Some(new_editor);
+                                }
+                                continue;
+                            }
                             // Check for stacked mode header arrow clicks
                             if state.stacked_mode && mouse.row < header_height {
                                 // Left arrow click (first 4 columns to cover " < ")
@@ -1711,6 +1785,10 @@ fn run_app_internal(
                         }
                         KeyCode::Char('e') => {
                             if !state.file_diffs.is_empty() {
+                                let _ = execute!(
+                                    terminal.backend_mut(),
+                                    PopKeyboardEnhancementFlags
+                                );
                                 execute!(
                                     terminal.backend_mut(),
                                     DisableMouseCapture,
@@ -1756,6 +1834,10 @@ fn run_app_internal(
                                     EnterAlternateScreen,
                                     EnableMouseCapture
                                 )?;
+                                let _ = execute!(
+                                    terminal.backend_mut(),
+                                    PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+                                );
                                 terminal.clear()?;
                             }
                         }
@@ -1988,6 +2070,7 @@ fn run_app_internal(
         }
     }
 
+    let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
     execute!(
         terminal.backend_mut(),
         DisableMouseCapture,

--- a/src/command/diff/render/diff_view.rs
+++ b/src/command/diff/render/diff_view.rs
@@ -5,11 +5,83 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
+use crate::command::diff::annotation::AnnotationEditor;
 use crate::command::diff::context::{compute_context_lines, ContextLine};
 use crate::command::diff::highlight::{highlight_line_spans, FileHighlighter};
 use crate::command::diff::search::{MatchPanel, SearchState};
 use crate::command::diff::state::{Annotation, AnnotationTarget};
 use crate::command::diff::theme;
+
+/// One overlay slot in the rendered diff: either a saved annotation or the
+/// active inline editor (new or editing an existing annotation).
+enum OverlaySlot<'a, 'e> {
+    Saved(&'a Annotation),
+    Editor(&'e AnnotationEditor<'e>),
+}
+
+impl<'a, 'e> OverlaySlot<'a, 'e> {
+    fn height(&self) -> usize {
+        match self {
+            OverlaySlot::Saved(a) => a.content.lines().count() + 2,
+            OverlaySlot::Editor(e) => e.desired_height(),
+        }
+    }
+
+    fn target(&self) -> &AnnotationTarget {
+        match self {
+            OverlaySlot::Saved(a) => &a.target,
+            OverlaySlot::Editor(e) => &e.target,
+        }
+    }
+}
+
+/// Build the file-level overlay slot list for a given file, weaving in the
+/// active editor when it targets this file (replacing the existing annotation
+/// when editing, appended at the end when creating).
+fn build_file_slots<'a, 'e>(
+    saved: &[&'a Annotation],
+    editor: Option<&'e AnnotationEditor<'e>>,
+    filename: &str,
+) -> Vec<OverlaySlot<'a, 'e>> {
+    let edit_id = editor
+        .filter(|e| e.filename == filename && matches!(e.target, AnnotationTarget::File))
+        .and_then(|e| e.id);
+    let mut slots: Vec<OverlaySlot<'a, 'e>> = saved
+        .iter()
+        .filter(|a| Some(a.id) != edit_id)
+        .map(|a| OverlaySlot::Saved(*a))
+        .collect();
+    if let Some(e) = editor {
+        if e.filename == filename && matches!(e.target, AnnotationTarget::File) {
+            slots.push(OverlaySlot::Editor(e));
+        }
+    }
+    slots
+}
+
+/// Build the line-range overlay slot list for a given file.
+fn build_line_slots<'a, 'e>(
+    saved: &[&'a Annotation],
+    editor: Option<&'e AnnotationEditor<'e>>,
+    filename: &str,
+) -> Vec<OverlaySlot<'a, 'e>> {
+    let edit_id = editor
+        .filter(|e| {
+            e.filename == filename && matches!(e.target, AnnotationTarget::LineRange { .. })
+        })
+        .and_then(|e| e.id);
+    let mut slots: Vec<OverlaySlot<'a, 'e>> = saved
+        .iter()
+        .filter(|a| Some(a.id) != edit_id)
+        .map(|a| OverlaySlot::Saved(*a))
+        .collect();
+    if let Some(e) = editor {
+        if e.filename == filename && matches!(e.target, AnnotationTarget::LineRange { .. }) {
+            slots.push(OverlaySlot::Editor(e));
+        }
+    }
+    slots
+}
 use crate::command::diff::types::{
     ChangeType, DiffFullscreen, DiffLine, DiffPanelFocus, DiffViewSettings, FileDiff, FocusedPanel,
     InlineSegment, Selection, SelectionMode, SidebarItem,
@@ -728,15 +800,15 @@ fn render_context_lines(
 
 use crate::vcs::StackedCommitInfo;
 
-/// Compute side_by_side index ranges for line-range annotations.
-/// Returns `(first_sbs_idx, last_sbs_idx, panel)` for each annotation that has matching lines.
-fn compute_ann_index_ranges(
-    line_annotations: &[&Annotation],
+/// Compute side_by_side index ranges for line-range targets.
+/// Returns `(first_sbs_idx, last_sbs_idx, panel)` for each target that has matching lines.
+fn compute_target_index_ranges(
+    targets: &[AnnotationTarget],
     side_by_side: &[DiffLine],
 ) -> Vec<(usize, usize, DiffPanelFocus)> {
     let mut ranges = Vec::new();
-    for ann in line_annotations {
-        if let AnnotationTarget::LineRange { panel, start_line, end_line, .. } = &ann.target {
+    for target in targets {
+        if let AnnotationTarget::LineRange { panel, start_line, end_line, .. } = target {
             let mut first_idx: Option<usize> = None;
             let mut last_idx: Option<usize> = None;
             for (idx, dl) in side_by_side.iter().enumerate() {
@@ -755,6 +827,11 @@ fn compute_ann_index_ranges(
         }
     }
     ranges
+}
+
+/// Collect line-range targets from a slot list.
+fn slot_targets(slots: &[OverlaySlot]) -> Vec<AnnotationTarget> {
+    slots.iter().map(|s| s.target().clone()).collect()
 }
 
 /// Check if a side_by_side index falls within any annotation range, optionally filtering by panel.
@@ -792,9 +869,9 @@ fn make_indicator_span(
     }
 }
 
-/// Total rendered height of file-level annotation overlays.
-fn file_annotation_height(annotations: &[&Annotation]) -> usize {
-    annotations.iter().map(|a| a.content.lines().count() + 2).sum()
+/// Total rendered height of file-level overlay slots.
+fn file_slots_height(slots: &[OverlaySlot]) -> usize {
+    slots.iter().map(|s| s.height()).sum()
 }
 
 /// Render annotation overlays at specified positions.
@@ -802,6 +879,10 @@ fn file_annotation_height(annotations: &[&Annotation]) -> usize {
 /// This function renders annotation boxes that can span single or multiple panels.
 /// The `content_x`, `content_start_y`, `content_width`, and `max_area` parameters
 /// allow flexible positioning for both single-panel and side-by-side views.
+///
+/// Each overlay's screen rect is appended to `annotation_rects` so mouse handlers
+/// can hit-test clicks against existing annotations.
+#[allow(clippy::too_many_arguments)]
 fn render_annotation_overlays(
     frame: &mut Frame,
     overlays: &[(usize, &Annotation)],
@@ -812,6 +893,7 @@ fn render_annotation_overlays(
     bg: Color,
     t: &crate::command::diff::theme::Theme,
     suppress_gutter: bool,
+    annotation_rects: &mut Vec<(u64, Rect)>,
 ) {
     // Annotation accent color — a subtle but visible tint
     let ann_accent = t.ui.highlight;
@@ -906,6 +988,61 @@ fn render_annotation_overlays(
 
         let ann_para = Paragraph::new(ann_lines).style(Style::default().bg(bg));
         frame.render_widget(ann_para, overlay_area);
+
+        annotation_rects.push((annotation.id, overlay_area));
+    }
+}
+
+/// Render a single overlay slot (saved annotation or editor) at a given position.
+/// Append the resulting rect to `annotation_rects` if the slot is a saved annotation.
+#[allow(clippy::too_many_arguments)]
+fn render_overlay_slot(
+    frame: &mut Frame,
+    line_pos: usize,
+    slot: &OverlaySlot,
+    content_x: u16,
+    content_start_y: u16,
+    content_width: u16,
+    max_area: Rect,
+    bg: Color,
+    t: &crate::command::diff::theme::Theme,
+    suppress_gutter: bool,
+    annotation_rects: &mut Vec<(u64, Rect)>,
+    editor_rect: &mut Option<Rect>,
+) {
+    match slot {
+        OverlaySlot::Saved(a) => render_annotation_overlays(
+            frame,
+            &[(line_pos, a)],
+            content_x,
+            content_start_y,
+            content_width,
+            max_area,
+            bg,
+            t,
+            suppress_gutter,
+            annotation_rects,
+        ),
+        OverlaySlot::Editor(editor) => {
+            let screen_y = content_start_y + line_pos as u16;
+            if screen_y >= max_area.y + max_area.height {
+                return;
+            }
+            let available = (max_area.y + max_area.height).saturating_sub(screen_y) as usize;
+            if available == 0 {
+                return;
+            }
+            let height = editor.desired_height().min(available) as u16;
+            let area = Rect::new(content_x, screen_y, content_width, height);
+            editor.render_inline(
+                frame,
+                area,
+                t.ui.highlight,
+                bg,
+                !suppress_gutter && matches!(editor.target, AnnotationTarget::LineRange { .. }),
+            );
+            *editor_rect = Some(area);
+        }
     }
 }
 
@@ -953,7 +1090,8 @@ pub fn render_diff(
     viewed_hunks: &HashSet<usize>,
     total_added: usize,
     total_removed: usize,
-) -> (usize, Vec<(usize, usize)>) {
+    editor: Option<&AnnotationEditor>,
+) -> (usize, Vec<(usize, usize)>, Vec<(u64, Rect)>, Option<Rect>) {
     let area = frame.area();
     let t = theme::get();
     let bg = t.ui.bg;
@@ -1058,7 +1196,7 @@ pub fn render_diff(
                 area_width: area.width,
             },
         );
-        return (0, Vec::new());
+        return (0, Vec::new(), Vec::new(), None);
     }
 
     // side_by_side is now passed as a parameter (pre-computed and cached)
@@ -1071,6 +1209,10 @@ pub fn render_diff(
     let content_row_offset: usize;
     // Track inline annotation overlay gaps for mouse coordinate mapping
     let mut overlay_gaps: Vec<(usize, usize)> = Vec::new();
+    // Track rendered annotation screen rects for click hit-testing
+    let mut annotation_rects: Vec<(u64, Rect)> = Vec::new();
+    // Tracks the screen rect of the inline editor, when one is rendered this frame.
+    let mut editor_rect: Option<Rect> = None;
 
     let border_style = Style::default().fg(t.ui.border_unfocused);
     let title_style = if focused_panel == FocusedPanel::DiffView {
@@ -1103,7 +1245,10 @@ pub fn render_diff(
             .filter(|a| a.filename == diff.filename && matches!(a.target, AnnotationTarget::LineRange { .. }))
             .collect();
 
-        let annotation_height = file_annotation_height(&file_annotations);
+        let file_slots = build_file_slots(&file_annotations, editor, &diff.filename);
+        let line_slots = build_line_slots(&line_annotations, editor, &diff.filename);
+
+        let annotation_height = file_slots_height(&file_slots);
         content_row_offset = context_count + annotation_height;
 
         let base_content_height = visible_height.saturating_sub(context_count);
@@ -1116,7 +1261,7 @@ pub fn render_diff(
             .collect();
 
         let mut new_lines: Vec<Line> = Vec::new();
-        let mut annotation_overlays: Vec<(usize, &Annotation)> = Vec::new();
+        let mut slot_overlays: Vec<(usize, &OverlaySlot)> = Vec::new();
 
         if settings.context.enabled && context_count > 0 {
             render_context_lines(
@@ -1129,18 +1274,18 @@ pub fn render_diff(
             );
         }
 
-        // Show file-level annotations at top
-        for annotation in &file_annotations {
-            let content_lines: Vec<&str> = annotation.content.lines().collect();
-            let num_lines = content_lines.len() + 2;
-            let annotation_start = new_lines.len();
+        // Show file-level slots at top (annotations + editor when file-targeted)
+        for slot in &file_slots {
+            let num_lines = slot.height();
+            let slot_start = new_lines.len();
             for _ in 0..num_lines {
                 new_lines.push(Line::from(vec![Span::raw("")]));
             }
-            annotation_overlays.push((annotation_start, annotation));
+            slot_overlays.push((slot_start, slot));
         }
 
-        let ann_index_ranges = compute_ann_index_ranges(&line_annotations, side_by_side);
+        let line_targets = slot_targets(&line_slots);
+        let ann_index_ranges = compute_target_index_ranges(&line_targets, side_by_side);
         let annotation_indicator_style = Style::default().fg(t.ui.highlight);
         let focus_style = Style::default().fg(t.ui.border_focused);
 
@@ -1196,17 +1341,17 @@ pub fn render_diff(
                 new_lines.push(Line::from(spans));
             }
 
-            // Check if this line is the end_line for any line-range annotation
-            for annotation in &line_annotations {
-                if let AnnotationTarget::LineRange { panel, end_line, .. } = &annotation.target {
+            // Check if this line is the end_line for any line-range slot
+            for slot in &line_slots {
+                if let AnnotationTarget::LineRange { panel, end_line, .. } = slot.target() {
                     if diff_line.line_number(*panel) == Some(*end_line) {
-                        let num_ann_lines = annotation.content.lines().count() + 2;
+                        let num_ann_lines = slot.height();
                         let line_pos = new_lines.len();
                         overlay_gaps.push((i, num_ann_lines));
                         for _ in 0..num_ann_lines {
                             new_lines.push(Line::from(vec![Span::raw("")]));
                         }
-                        annotation_overlays.push((line_pos, annotation));
+                        slot_overlays.push((line_pos, slot));
                     }
                 }
             }
@@ -1220,11 +1365,26 @@ pub fn render_diff(
         );
         frame.render_widget(new_para, main_area);
 
-        // Render annotation overlays
+        // Render overlay slots (saved annotations + active editor)
         let content_x = main_area.x + 1;
         let content_start_y = main_area.y + 1;
         let content_width = main_area.width.saturating_sub(2);
-        render_annotation_overlays(frame, &annotation_overlays, content_x, content_start_y, content_width, main_area, bg, t, false);
+        for &(line_pos, slot) in &slot_overlays {
+            render_overlay_slot(
+                frame,
+                line_pos,
+                slot,
+                content_x,
+                content_start_y,
+                content_width,
+                main_area,
+                bg,
+                t,
+                false,
+                &mut annotation_rects,
+                &mut editor_rect,
+            );
+        }
     } else if is_deleted_file {
         let visible_height = main_area.height.saturating_sub(2) as usize;
         let old_context = compute_context_lines(
@@ -1249,7 +1409,10 @@ pub fn render_diff(
             .filter(|a| a.filename == diff.filename && matches!(a.target, AnnotationTarget::LineRange { .. }))
             .collect();
 
-        let annotation_height = file_annotation_height(&file_annotations);
+        let file_slots = build_file_slots(&file_annotations, editor, &diff.filename);
+        let line_slots = build_line_slots(&line_annotations, editor, &diff.filename);
+
+        let annotation_height = file_slots_height(&file_slots);
         content_row_offset = context_count + annotation_height;
 
         let base_content_height = visible_height.saturating_sub(context_count);
@@ -1262,7 +1425,7 @@ pub fn render_diff(
             .collect();
 
         let mut old_lines: Vec<Line> = Vec::new();
-        let mut annotation_overlays: Vec<(usize, &Annotation)> = Vec::new();
+        let mut slot_overlays: Vec<(usize, &OverlaySlot)> = Vec::new();
 
         if settings.context.enabled && context_count > 0 {
             render_context_lines(
@@ -1275,18 +1438,18 @@ pub fn render_diff(
             );
         }
 
-        // Show file-level annotations at top
-        for annotation in &file_annotations {
-            let content_lines: Vec<&str> = annotation.content.lines().collect();
-            let num_lines = content_lines.len() + 2;
-            let annotation_start = old_lines.len();
+        // Show file-level slots at top (annotations + editor when file-targeted)
+        for slot in &file_slots {
+            let num_lines = slot.height();
+            let slot_start = old_lines.len();
             for _ in 0..num_lines {
                 old_lines.push(Line::from(vec![Span::raw("")]));
             }
-            annotation_overlays.push((annotation_start, annotation));
+            slot_overlays.push((slot_start, slot));
         }
 
-        let ann_index_ranges = compute_ann_index_ranges(&line_annotations, side_by_side);
+        let line_targets = slot_targets(&line_slots);
+        let ann_index_ranges = compute_target_index_ranges(&line_targets, side_by_side);
         let annotation_indicator_style = Style::default().fg(t.ui.highlight);
         let focus_style = Style::default().fg(t.ui.border_focused);
 
@@ -1342,17 +1505,17 @@ pub fn render_diff(
                 old_lines.push(Line::from(spans));
             }
 
-            // Check if this line is the end_line for any line-range annotation
-            for annotation in &line_annotations {
-                if let AnnotationTarget::LineRange { panel, end_line, .. } = &annotation.target {
+            // Check if this line is the end_line for any line-range slot
+            for slot in &line_slots {
+                if let AnnotationTarget::LineRange { panel, end_line, .. } = slot.target() {
                     if diff_line.line_number(*panel) == Some(*end_line) {
-                        let num_ann_lines = annotation.content.lines().count() + 2;
+                        let num_ann_lines = slot.height();
                         let line_pos = old_lines.len();
                         overlay_gaps.push((i, num_ann_lines));
                         for _ in 0..num_ann_lines {
                             old_lines.push(Line::from(vec![Span::raw("")]));
                         }
-                        annotation_overlays.push((line_pos, annotation));
+                        slot_overlays.push((line_pos, slot));
                     }
                 }
             }
@@ -1366,11 +1529,26 @@ pub fn render_diff(
         );
         frame.render_widget(old_para, main_area);
 
-        // Render annotation overlays
+        // Render overlay slots (saved annotations + active editor)
         let content_x = main_area.x + 1;
         let content_start_y = main_area.y + 1;
         let content_width = main_area.width.saturating_sub(2);
-        render_annotation_overlays(frame, &annotation_overlays, content_x, content_start_y, content_width, main_area, bg, t, false);
+        for &(line_pos, slot) in &slot_overlays {
+            render_overlay_slot(
+                frame,
+                line_pos,
+                slot,
+                content_x,
+                content_start_y,
+                content_width,
+                main_area,
+                bg,
+                t,
+                false,
+                &mut annotation_rects,
+                &mut editor_rect,
+            );
+        }
     } else {
         let (old_area, new_area) = match diff_fullscreen {
             DiffFullscreen::OldOnly => (Some(main_area), None),
@@ -1413,7 +1591,7 @@ pub fn render_diff(
 
         let mut old_lines: Vec<Line> = Vec::new();
         let mut new_lines: Vec<Line> = Vec::new();
-        let mut annotation_overlays: Vec<(usize, &Annotation)> = Vec::new();
+        let mut slot_overlays: Vec<(usize, &OverlaySlot)> = Vec::new();
 
         // Collect file-level annotations
         let file_annotations: Vec<&Annotation> = annotations
@@ -1427,7 +1605,10 @@ pub fn render_diff(
             .filter(|a| a.filename == diff.filename && matches!(a.target, AnnotationTarget::LineRange { .. }))
             .collect();
 
-        let file_ann_height = file_annotation_height(&file_annotations);
+        let file_slots = build_file_slots(&file_annotations, editor, &diff.filename);
+        let line_slots = build_line_slots(&line_annotations, editor, &diff.filename);
+
+        let file_ann_height = file_slots_height(&file_slots);
         content_row_offset = context_count + file_ann_height;
 
         if settings.context.enabled && context_count > 0 {
@@ -1479,11 +1660,10 @@ pub fn render_diff(
             false
         };
 
-        // Add file-level annotations at the top (after context lines)
-        for annotation in &file_annotations {
-            let content_lines_count = annotation.content.lines().count();
-            let num_lines = content_lines_count + 2;
-            let annotation_start = old_lines.len(); // same position in both panels
+        // Add file-level slots at the top (after context lines)
+        for slot in &file_slots {
+            let num_lines = slot.height();
+            let slot_start = old_lines.len(); // same position in both panels
             for _ in 0..num_lines {
                 if old_area.is_some() {
                     old_lines.push(Line::from(vec![Span::raw("")]));
@@ -1492,10 +1672,11 @@ pub fn render_diff(
                     new_lines.push(Line::from(vec![Span::raw("")]));
                 }
             }
-            annotation_overlays.push((annotation_start, annotation));
+            slot_overlays.push((slot_start, slot));
         }
 
-        let ann_index_ranges = compute_ann_index_ranges(&line_annotations, side_by_side);
+        let line_targets = slot_targets(&line_slots);
+        let ann_index_ranges = compute_target_index_ranges(&line_targets, side_by_side);
 
         // Track rendered rows for new-panel border annotation markers (paragraph-relative)
         let mut border_marker_rows: Vec<usize> = Vec::new();
@@ -1711,11 +1892,11 @@ pub fn render_diff(
                 new_lines.push(Line::from(new_spans));
             }
 
-            // Check if this line is the end_line for any line-range annotation
-            for annotation in &line_annotations {
-                if let AnnotationTarget::LineRange { panel, end_line, .. } = &annotation.target {
+            // Check if this line is the end_line for any line-range slot
+            for slot in &line_slots {
+                if let AnnotationTarget::LineRange { panel, end_line, .. } = slot.target() {
                     if diff_line.line_number(*panel) == Some(*end_line) {
-                        let num_lines = annotation.content.lines().count() + 2;
+                        let num_lines = slot.height();
 
                         let line_pos = if old_area.is_some() {
                             old_lines.len()
@@ -1738,7 +1919,7 @@ pub fn render_diff(
                             rendered_row += 1;
                         }
 
-                        annotation_overlays.push((line_pos, annotation));
+                        slot_overlays.push((line_pos, slot));
                     }
                 }
             }
@@ -1794,11 +1975,11 @@ pub fn render_diff(
             }
         }
 
-        // Render annotation overlays per-panel for line-range annotations,
-        // spanning both panels for file-level annotations
+        // Render overlay slots (saved annotations + active editor) per-panel for line-range,
+        // spanning both panels for file-level.
         let is_side_by_side = old_area.is_some() && new_area.is_some();
-        for &(line_pos, annotation) in &annotation_overlays {
-            let (overlay_x, overlay_width, overlay_start_y, suppress_gutter) = match &annotation.target {
+        for &(line_pos, slot) in &slot_overlays {
+            let (overlay_x, overlay_width, overlay_start_y, suppress_gutter) = match slot.target() {
                 AnnotationTarget::File => {
                     // File-level: span both panels
                     let render_area = old_area.or(new_area).unwrap_or(main_area);
@@ -1824,9 +2005,10 @@ pub fn render_diff(
                     (area.x + 1, area.width.saturating_sub(2), area.y + 1, suppress)
                 }
             };
-            render_annotation_overlays(
+            render_overlay_slot(
                 frame,
-                &[(line_pos, annotation)],
+                line_pos,
+                slot,
                 overlay_x,
                 overlay_start_y,
                 overlay_width,
@@ -1834,20 +2016,21 @@ pub fn render_diff(
                 bg,
                 t,
                 suppress_gutter,
+                &mut annotation_rects,
+                &mut editor_rect,
             );
         }
 
-        // Extend border markers through new-panel annotation overlay rows on the shared border
+        // Extend border markers through new-panel slot overlay rows on the shared border
         if let (Some(old_a), Some(_)) = (old_area, new_area) {
             let border_x = old_a.x + old_a.width - 1;
             let content_start = old_a.y + 1;
             let buf = frame.buffer_mut();
 
-            for &(line_pos, annotation) in &annotation_overlays {
-                if let AnnotationTarget::LineRange { panel, .. } = &annotation.target {
+            for &(line_pos, slot) in &slot_overlays {
+                if let AnnotationTarget::LineRange { panel, .. } = slot.target() {
                     if matches!(panel, DiffPanelFocus::New | DiffPanelFocus::None) {
-                        let content_lines_count = annotation.content.lines().count();
-                        let num_rows = content_lines_count + 2;
+                        let num_rows = slot.height();
                         for row_offset in 0..num_rows {
                             let screen_row = content_start + line_pos as u16 + row_offset as u16;
                             if screen_row < old_a.y + old_a.height - 1 {
@@ -1903,5 +2086,5 @@ pub fn render_diff(
         },
     );
 
-    (content_row_offset, overlay_gaps)
+    (content_row_offset, overlay_gaps, annotation_rects, editor_rect)
 }

--- a/src/command/diff/state.rs
+++ b/src/command/diff/state.rs
@@ -203,6 +203,14 @@ pub struct AppState {
     /// visible content line index after which an overlay gap of `gap_height` rows appears.
     /// Used by mouse handlers to correctly map screen rows to side_by_side indices.
     pub annotation_overlay_gaps: Vec<(usize, usize)>,
+    /// Screen rectangles of currently-rendered annotation overlays.
+    /// Set by render_diff each frame; used by mouse handlers to open the inline
+    /// editor when the user clicks an existing annotation.
+    pub annotation_rects: Vec<(u64, ratatui::layout::Rect)>,
+    /// Screen rectangle of the active inline annotation editor, when present.
+    /// Set by render_diff each frame; used by mouse handlers to detect clicks
+    /// outside the editor (save if non-empty, cancel if empty).
+    pub editor_rect: Option<ratatui::layout::Rect>,
     /// Total added lines across all files in the current diff. Recomputed on reload.
     pub total_added: usize,
     /// Total removed lines across all files in the current diff. Recomputed on reload.
@@ -304,6 +312,8 @@ impl AppState {
             search_dirty: true,
             content_row_offset: 0,
             annotation_overlay_gaps: Vec::new(),
+            annotation_rects: Vec::new(),
+            editor_rect: None,
             total_added,
             total_removed,
         }
@@ -462,6 +472,8 @@ impl AppState {
         self.search_dirty = true;
         self.content_row_offset = 0;
         self.annotation_overlay_gaps.clear();
+        self.annotation_rects.clear();
+        self.editor_rect = None;
     }
 
     /// Adjust a screen-relative content row for annotation overlay gaps.


### PR DESCRIPTION
## Summary

Replace the centered annotation modal dialog with an inline bordered textbox rendered in the same slot the saved annotation will occupy, and make existing annotation overlays click-to-focus.

## Problem

Creating or editing an annotation popped up a 60×10 centered modal that occluded the surrounding diff — you stopped seeing the code you were annotating mid-thought. Existing annotation overlays on the canvas were inert; the only way to edit one was via the `I` modal list, which required two extra steps and a context switch.

## UX Flow

```text
Current flow
└─ press `i`
   └─ modal pops over the diff
      └─ type → Enter saves → modal closes

   `I` → list modal → arrow → `e` to edit
   └─ centered modal again

Desired flow
└─ press `i`
   └─ inline editor appears below the targeted lines (or at top for file-level)
      └─ Enter saves, Esc cancels, click-outside saves-if-not-empty

   click any saved annotation box
   └─ editor replaces the overlay in place, cursor at end
```

## Solution

`AnnotationEditor::render_inline` paints a bordered box (matching the saved-overlay style — rounded borders, gutter indicator for line-range annotations) at a given `Rect`. `render_diff` treats the active editor as a virtual overlay slot via a new `OverlaySlot` enum: it injects a slot for a new annotation, or replaces the matching annotation's slot when editing existing. Layout is unified so `annotation_overlay_gaps` (mouse-coord mapping) reserves space for the editor the same way it does for saved overlays.

Click-to-edit hangs off a new `annotation_rects: Vec<(u64, Rect)>` on `AppState`, populated each frame by `render_annotation_overlays`. The mouse `Down(Left)` handler hit-tests against it; the matching annotation gets loaded via `with_existing` into a fresh editor. An `editor_rect` field on state lets the same handler distinguish click-inside (no-op) from click-outside (save if non-empty, cancel/delete if empty).

To make `Shift+Enter` deliverable as such (rather than bare `Enter`), the TUI opts into the kitty keyboard protocol via `PushKeyboardEnhancementFlags(DISAMBIGUATE_ESCAPE_CODES)` at startup and on resume after external `$EDITOR`. Terminals that don't support it silently ignore the sequence; `Ctrl+J` continues to work universally as a fallback newline.