### PR TITLE
feat(diff): add foldable outline view modes

### DIFF
--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -423,10 +423,13 @@ fn run_app_internal(
             state.update_search_matches();
             // Ensure highlighters are cached (only recomputed when file changes)
             state.get_highlighters();
+            // Ensure the row plan is cached (drives the renderer in every mode)
+            state.ensure_plan();
             let diff = &state.file_diffs[state.current_file];
             let side_by_side = state.side_by_side_ref();
             let hunks = state.hunks_ref();
             let (old_hl, new_hl) = state.highlighters_ref().unwrap();
+            let plan = state.plan_ref();
             let hunk_count = hunks.len();
             let empty_viewed_hunks: std::collections::HashSet<usize> =
                 std::collections::HashSet::new();
@@ -484,6 +487,8 @@ fn run_app_internal(
                     state.total_added,
                     state.total_removed,
                     annotation_editor.as_ref(),
+                    state.view_mode,
+                    plan,
                 );
                 row_offset.set(offset);
                 *rects_cell.borrow_mut() = rects;
@@ -591,7 +596,7 @@ fn run_app_internal(
             let visible_height = terminal.size()?.height.saturating_sub(2) as usize;
             let bottom_padding = 5;
             let max_scroll = if !state.file_diffs.is_empty() {
-                let total_lines = state.total_lines();
+                let total_lines = state.active_line_count();
                 total_lines.saturating_sub(visible_height.saturating_sub(bottom_padding))
             } else {
                 0
@@ -833,14 +838,14 @@ fn run_app_internal(
                                             terminal.size()?.height.saturating_sub(5) as usize;
                                         ensure_sidebar_visible(&mut state, visible_height);
                                     }
-                                    // Compute max_scroll for the just-switched file
-                                    // before pinning scroll, so we don't overscroll
-                                    // past the last visible row.
+                                    // Map the target side-by-side line to a row in
+                                    // the active plan (identity in full diff), then
+                                    // pin it near the top without overscrolling.
                                     state.ensure_cache();
-                                    let sbs_len = state.side_by_side_ref().len();
                                     let vh = terminal.size()?.height.saturating_sub(5) as usize;
-                                    let max_scroll = sbs_len.saturating_sub(vh) as u16;
-                                    state.scroll = (sbs_line_index as u16).min(max_scroll);
+                                    let plan_row = state.active_row_for_sbs(sbs_line_index);
+                                    let max_scroll = state.active_line_count().saturating_sub(vh) as u16;
+                                    state.scroll = (plan_row as u16).min(max_scroll);
                                     active_modal = None;
                                 }
                                 ModalResult::Dismissed | ModalResult::Selected(_, _) => {
@@ -1035,11 +1040,13 @@ fn run_app_internal(
                                                 Some(y) => y,
                                                 None => continue, // Clicked inside an annotation overlay
                                             };
-                                        let line = state.scroll as usize + adjusted_y;
-                                        let sbs_len = state.side_by_side_ref().len();
-                                        if line >= sbs_len {
-                                            continue;
-                                        }
+                                        // Map the clicked plan row to a diff line;
+                                        // a click on a fold row has no target.
+                                        let plan_idx = state.scroll as usize + adjusted_y;
+                                        let line = match state.sbs_index_for_plan_row(plan_idx) {
+                                            Some(l) => l,
+                                            None => continue,
+                                        };
 
                                         let panel_x = match panel {
                                             DiffPanelFocus::Old => layout.old_panel_x,
@@ -1089,10 +1096,9 @@ fn run_app_internal(
                                         // Adjust for inline annotation overlay gaps (clamped for drag)
                                         let adjusted_y =
                                             state.adjust_for_overlay_gaps_clamped(content_y);
-                                        let line = state.scroll as usize + adjusted_y;
-                                        // Clamp to valid side_by_side range
-                                        let sbs_len = state.side_by_side_ref().len();
-                                        let line = line.min(sbs_len.saturating_sub(1));
+                                        // Map the dragged-over plan row to a diff line.
+                                        let plan_idx = state.scroll as usize + adjusted_y;
+                                        let line = state.sbs_index_for_plan_row_clamped(plan_idx);
 
                                         let panel_x = match panel {
                                             DiffPanelFocus::Old => layout.old_panel_x,
@@ -1398,6 +1404,34 @@ fn run_app_internal(
                             state.diff_fullscreen = DiffFullscreen::None;
                             state.mark_search_dirty();
                         }
+                        KeyCode::Char('O') => {
+                            // Cycle: full diff → outline → outline+diff → full diff.
+                            // Anchor on the focused hunk and keep it at the same
+                            // screen height so the view doesn't jump on switch.
+                            let anchor_line = state.focused_hunk_line();
+                            let offset = anchor_line.map(|l| {
+                                state
+                                    .active_row_for_line(l)
+                                    .saturating_sub(state.scroll as usize)
+                            });
+                            state.view_mode = state.view_mode.next();
+                            state.focused_panel = FocusedPanel::DiffView;
+                            state.h_scroll = 0;
+                            match (anchor_line, offset) {
+                                (Some(l), Some(off)) => {
+                                    let new_row = state.active_row_for_line(l);
+                                    let max = state.active_line_count().saturating_sub(1);
+                                    state.scroll = new_row.saturating_sub(off).min(max) as u16;
+                                }
+                                _ => state.scroll = 0,
+                            }
+                            state.mark_search_dirty();
+                        }
+                        KeyCode::Char('c') if state.view_mode.is_outline() => {
+                            // Toggle "changed declarations only" filter in the folded view.
+                            state.outline_changed_only = !state.outline_changed_only;
+                            state.scroll = 0;
+                        }
                         KeyCode::Down
                             if state.search_state.has_query()
                                 && state.focused_panel == FocusedPanel::DiffView =>
@@ -1680,8 +1714,9 @@ fn run_app_internal(
                                 };
                                 if !hunks.is_empty() {
                                     state.focused_hunk = Some(next_hunk);
+                                    let row = state.active_row_for_sbs(hunks[next_hunk]);
                                     state.scroll = adjust_scroll_for_hunk(
-                                        hunks[next_hunk],
+                                        row,
                                         state.scroll,
                                         visible_height,
                                         max_scroll,
@@ -1704,8 +1739,9 @@ fn run_app_internal(
                                 };
                                 if !hunks.is_empty() {
                                     state.focused_hunk = Some(prev_hunk);
+                                    let row = state.active_row_for_sbs(hunks[prev_hunk]);
                                     state.scroll = adjust_scroll_for_hunk(
-                                        hunks[prev_hunk],
+                                        row,
                                         state.scroll,
                                         visible_height,
                                         max_scroll,
@@ -2140,6 +2176,23 @@ fn run_app_internal(
                                             KeyBind {
                                                 key: "=",
                                                 description: "Reset fullscreen to side-by-side",
+                                            },
+                                        ],
+                                    },
+                                    KeyBindSection {
+                                        title: "Outline (folded diff)",
+                                        bindings: vec![
+                                            KeyBind {
+                                                key: "O",
+                                                description: "Cycle: diff → outline → outline+diff",
+                                            },
+                                            KeyBind {
+                                                key: "c",
+                                                description: "Fold to changed declarations only",
+                                            },
+                                            KeyBind {
+                                                key: "j/k, ctrl+d/u",
+                                                description: "Scroll (same as diff)",
                                             },
                                         ],
                                     },

--- a/src/command/diff/mod.rs
+++ b/src/command/diff/mod.rs
@@ -6,6 +6,7 @@ mod diff_algo;
 pub mod git;
 mod global_search;
 pub mod highlight;
+mod outline;
 mod render;
 mod search;
 mod state;

--- a/src/command/diff/outline.rs
+++ b/src/command/diff/outline.rs
@@ -1,0 +1,687 @@
+//! Structural outline extraction for the diff viewer's "outline" view mode.
+//!
+//! Walks a file's tree-sitter syntax tree and returns the declaration
+//! "skeleton" (classes, functions, fields, etc.) as a flat, depth-tagged list
+//! of signature lines. This is the same machinery [`super::context`] uses to
+//! find enclosing scopes, generalized to collect *all* declarations and to also
+//! include member declarations (struct/class fields, properties, enum members).
+//!
+//! Languages without an outline query fall through to an empty result, which
+//! the renderer surfaces as a "no outline for this file type" hint.
+
+use std::path::Path;
+
+use once_cell::sync::Lazy;
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Language, Parser, Query, QueryCursor};
+
+/// A single declaration in a file's outline. The renderer folds the diff so
+/// only these declarations' signature lines stay visible, so an entry just
+/// needs to locate the declaration's line span; the visible text/colors come
+/// from the real diff line at that position.
+#[derive(Clone, Debug)]
+pub struct OutlineEntry {
+    /// 1-based line number of the declaration's first line (the side being shown).
+    pub line_number: usize,
+    /// 0-based start row of the declaration node.
+    pub start_row: usize,
+    /// 0-based end row of the declaration node.
+    pub end_row: usize,
+    /// Whether this declaration's line span intersects a changed hunk.
+    /// Filled in by the caller (the diff view state), `false` from extraction.
+    pub changed: bool,
+}
+
+// Outline queries per language. These capture whole declaration nodes; the
+// renderer shows only each node's first line. Compared to the context queries
+// in `context.rs`, these drop control-flow nodes (if/for/while/...) and add
+// member declarations — most importantly fields/properties.
+//
+// Each language lists a primary (richer) query and a known-good fallback. If
+// the primary fails to compile against the bundled grammar (e.g. a node name
+// differs), the fallback keeps the outline working with fewer node kinds.
+
+const RUST_OUTLINE: &str = r#"
+(function_item) @item
+(function_signature_item) @item
+(impl_item) @item
+(struct_item) @item
+(enum_item) @item
+(union_item) @item
+(trait_item) @item
+(mod_item) @item
+(macro_definition) @item
+(const_item) @item
+(static_item) @item
+(type_item) @item
+(field_declaration) @item
+(enum_variant) @item
+(if_expression) @block
+(match_expression) @block
+(for_expression) @block
+(while_expression) @block
+(loop_expression) @block
+"#;
+const RUST_OUTLINE_FALLBACK: &str = r#"
+(function_item) @item
+(impl_item) @item
+(struct_item) @item
+(enum_item) @item
+(trait_item) @item
+(mod_item) @item
+"#;
+
+// Real TS/React structure is dominated by `const X = <expr>` at module scope —
+// components (arrows, `memo(...)`, `styled(...)`), hooks, plus schemas, column
+// defs, configs (object/array/call values). So capture *every* top-level
+// const/let binding regardless of its value, not just function-valued ones.
+// Nested bindings are only captured when function-valued (handlers), so local
+// vars like `const [x, setX] = useState()` and inline callbacks stay out.
+const TYPESCRIPT_OUTLINE: &str = r#"
+(function_declaration) @item
+(class_body (method_definition) @item)
+(class_declaration) @item
+(abstract_class_declaration) @item
+(interface_declaration) @item
+(type_alias_declaration) @item
+(enum_declaration) @item
+(internal_module) @item
+(public_field_definition) @item
+(program (lexical_declaration (variable_declarator) @item))
+(program (variable_declaration (variable_declarator) @item))
+(program (export_statement (lexical_declaration (variable_declarator) @item)))
+(program (export_statement (variable_declaration (variable_declarator) @item)))
+(variable_declarator value: (arrow_function)) @item
+(variable_declarator value: (function_expression)) @item
+(if_statement) @block
+(for_statement) @block
+(for_in_statement) @block
+(while_statement) @block
+(do_statement) @block
+(switch_statement) @block
+(try_statement) @block
+"#;
+const TYPESCRIPT_OUTLINE_FALLBACK: &str = r#"
+(function_declaration) @item
+(class_body (method_definition) @item)
+(class_declaration) @item
+(interface_declaration) @item
+(variable_declarator value: (arrow_function)) @item
+"#;
+
+const JAVASCRIPT_OUTLINE: &str = r#"
+(function_declaration) @item
+(class_body (method_definition) @item)
+(class_declaration) @item
+(field_definition) @item
+(program (lexical_declaration (variable_declarator) @item))
+(program (variable_declaration (variable_declarator) @item))
+(program (export_statement (lexical_declaration (variable_declarator) @item)))
+(program (export_statement (variable_declaration (variable_declarator) @item)))
+(variable_declarator value: (arrow_function)) @item
+(variable_declarator value: (function_expression)) @item
+(if_statement) @block
+(for_statement) @block
+(for_in_statement) @block
+(while_statement) @block
+(do_statement) @block
+(switch_statement) @block
+(try_statement) @block
+"#;
+const JAVASCRIPT_OUTLINE_FALLBACK: &str = r#"
+(function_declaration) @item
+(class_body (method_definition) @item)
+(class_declaration) @item
+(variable_declarator value: (arrow_function)) @item
+"#;
+
+const PYTHON_OUTLINE: &str = r#"
+(function_definition) @item
+(class_definition) @item
+(if_statement) @block
+(for_statement) @block
+(while_statement) @block
+(try_statement) @block
+(with_statement) @block
+(match_statement) @block
+"#;
+
+const GO_OUTLINE: &str = r#"
+(function_declaration) @item
+(method_declaration) @item
+(type_declaration) @item
+(const_declaration) @item
+(var_declaration) @item
+(field_declaration) @item
+(if_statement) @block
+(for_statement) @block
+(expression_switch_statement) @block
+(type_switch_statement) @block
+(select_statement) @block
+"#;
+const GO_OUTLINE_FALLBACK: &str = r#"
+(function_declaration) @item
+(method_declaration) @item
+(type_declaration) @item
+"#;
+
+const CSHARP_OUTLINE: &str = r#"
+(namespace_declaration) @item
+(class_declaration) @item
+(struct_declaration) @item
+(interface_declaration) @item
+(enum_declaration) @item
+(record_declaration) @item
+(method_declaration) @item
+(constructor_declaration) @item
+(destructor_declaration) @item
+(property_declaration) @item
+(field_declaration) @item
+(event_declaration) @item
+(delegate_declaration) @item
+(enum_member_declaration) @item
+(if_statement) @block
+(for_statement) @block
+(foreach_statement) @block
+(while_statement) @block
+(switch_statement) @block
+(try_statement) @block
+"#;
+const CSHARP_OUTLINE_FALLBACK: &str = r#"
+(namespace_declaration) @item
+(class_declaration) @item
+(struct_declaration) @item
+(interface_declaration) @item
+(enum_declaration) @item
+(method_declaration) @item
+(property_declaration) @item
+"#;
+
+struct LanguageOutline {
+    language: Language,
+    query: Query,
+}
+
+/// Build a query from the first source that compiles against `lang`.
+fn build_query(lang: &Language, sources: &[&str]) -> Option<Query> {
+    sources.iter().find_map(|src| Query::new(lang, src).ok())
+}
+
+/// Register a language's outline query if it compiles against the grammar.
+fn register(
+    outlines: &mut Vec<(&'static str, LanguageOutline)>,
+    ext: &'static str,
+    lang: Language,
+    sources: &[&str],
+) {
+    if let Some(query) = build_query(&lang, sources) {
+        outlines.push((ext, LanguageOutline { language: lang, query }));
+    }
+}
+
+static LANGUAGE_OUTLINES: Lazy<Vec<(&'static str, LanguageOutline)>> = Lazy::new(|| {
+    let mut outlines = Vec::new();
+
+    register(
+        &mut outlines,
+        "rs",
+        tree_sitter_rust::LANGUAGE.into(),
+        &[RUST_OUTLINE, RUST_OUTLINE_FALLBACK],
+    );
+    register(
+        &mut outlines,
+        "ts",
+        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        &[TYPESCRIPT_OUTLINE, TYPESCRIPT_OUTLINE_FALLBACK],
+    );
+    register(
+        &mut outlines,
+        "tsx",
+        tree_sitter_typescript::LANGUAGE_TSX.into(),
+        &[TYPESCRIPT_OUTLINE, TYPESCRIPT_OUTLINE_FALLBACK],
+    );
+    register(
+        &mut outlines,
+        "js",
+        tree_sitter_javascript::LANGUAGE.into(),
+        &[JAVASCRIPT_OUTLINE, JAVASCRIPT_OUTLINE_FALLBACK],
+    );
+    register(
+        &mut outlines,
+        "jsx",
+        tree_sitter_javascript::LANGUAGE.into(),
+        &[JAVASCRIPT_OUTLINE, JAVASCRIPT_OUTLINE_FALLBACK],
+    );
+    register(
+        &mut outlines,
+        "py",
+        tree_sitter_python::LANGUAGE.into(),
+        &[PYTHON_OUTLINE],
+    );
+    register(
+        &mut outlines,
+        "go",
+        tree_sitter_go::LANGUAGE.into(),
+        &[GO_OUTLINE, GO_OUTLINE_FALLBACK],
+    );
+    register(
+        &mut outlines,
+        "cs",
+        tree_sitter_c_sharp::LANGUAGE.into(),
+        &[CSHARP_OUTLINE, CSHARP_OUTLINE_FALLBACK],
+    );
+
+    outlines
+});
+
+fn get_language_outline(filename: &str) -> Option<&'static LanguageOutline> {
+    let ext = Path::new(filename).extension().and_then(|e| e.to_str())?;
+    LANGUAGE_OUTLINES
+        .iter()
+        .find(|(e, _)| *e == ext)
+        .map(|(_, ctx)| ctx)
+}
+
+/// Parse `source` and return its declaration outline in source order.
+///
+/// Returns an empty vec for unsupported languages, empty input, or parse failures.
+pub fn compute_outline(source: &str, filename: &str) -> Vec<OutlineEntry> {
+    if source.is_empty() {
+        return Vec::new();
+    }
+
+    let Some(lang_outline) = get_language_outline(filename) else {
+        return Vec::new();
+    };
+
+    let mut parser = Parser::new();
+    if parser.set_language(&lang_outline.language).is_err() {
+        return Vec::new();
+    }
+
+    let Some(tree) = parser.parse(source, None) else {
+        return Vec::new();
+    };
+
+    // Control-flow nodes are captured as `@block` (vs `@item` for declarations).
+    // Blocks only earn a row when they span enough lines, so trivial one-liner
+    // guards don't flood the outline while real if/try/loop bodies still show.
+    const MIN_BLOCK_SPAN: usize = 2; // node must cover >= 3 source lines
+    let block_idx = lang_outline
+        .query
+        .capture_names()
+        .iter()
+        .position(|n| *n == "block");
+
+    // Collect (start_row, end_row) for every captured node.
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(&lang_outline.query, tree.root_node(), source.as_bytes());
+    while let Some(m) = matches.next() {
+        for capture in m.captures {
+            let node = capture.node;
+            let (start, end) = (node.start_position().row, node.end_position().row);
+            let is_block = block_idx == Some(capture.index as usize);
+            if is_block && end.saturating_sub(start) < MIN_BLOCK_SPAN {
+                continue;
+            }
+            spans.push((start, end));
+        }
+    }
+
+    // Sort by start row; for ties keep the widest span (outermost) first so the
+    // dedup below keeps the enclosing declaration when two share a start line.
+    spans.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+    spans.dedup_by_key(|(start, _)| *start);
+
+    spans
+        .iter()
+        .map(|&(start, end)| OutlineEntry {
+            line_number: start + 1,
+            start_row: start,
+            end_row: end,
+            changed: false,
+        })
+        .collect()
+}
+
+/// One row of the rendered diff in any view mode: either a real side-by-side
+/// line to render normally, or a collapsed region (a fold). This is the single
+/// coordinate space the renderer and every primitive (scroll, selection,
+/// annotations, hunk focus, mouse) operate on; a view mode is just an adapter
+/// that produces a different list of these.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DiffRow {
+    /// Index into the side-by-side diff of a line to render normally.
+    Code(usize),
+    /// A collapsed region of `lines` source lines that hid `added` insertions
+    /// and `removed` deletions. `at` is the side-by-side index where the region
+    /// begins (used to map positions between view modes).
+    Fold {
+        at: usize,
+        lines: usize,
+        added: usize,
+        removed: usize,
+    },
+}
+
+impl DiffRow {
+    /// The side-by-side index this row anchors to.
+    pub fn sbs_index(&self) -> usize {
+        match self {
+            DiffRow::Code(i) => *i,
+            DiffRow::Fold { at, .. } => *at,
+        }
+    }
+}
+
+/// Build the row plan for a view mode — the *only* place modes differ.
+///
+/// - Full diff: every side-by-side line as a `Code` row (plan index ==
+///   side-by-side index), so full-diff rendering is unchanged.
+/// - Outline: declaration signature lines stay visible; changed bodies collapse
+///   to `Fold` markers and unchanged bodies vanish entirely.
+/// - Outline+diff: declarations *and* changed lines stay visible; every hidden
+///   gap (changed or not) becomes a `Fold`, so adjacent visible line numbers are
+///   never misleadingly contiguous.
+///
+/// `entries` are the declarations from [`compute_outline`]; `use_old_side`
+/// selects which side's line numbers identify declarations (old for deleted
+/// files). `changed_only` keeps only declarations whose body/signature changed.
+pub fn row_plan(
+    view_mode: super::state::ViewMode,
+    side_by_side: &[super::types::DiffLine],
+    entries: &[OutlineEntry],
+    use_old_side: bool,
+    changed_only: bool,
+) -> Vec<DiffRow> {
+    use super::types::ChangeType;
+    use std::collections::HashSet;
+
+    if !view_mode.is_outline() {
+        return (0..side_by_side.len()).map(DiffRow::Code).collect();
+    }
+    let expand = view_mode.expands();
+
+    let header_lines: HashSet<usize> = entries
+        .iter()
+        .filter(|e| !changed_only || e.changed)
+        .map(|e| e.line_number)
+        .collect();
+
+    let mut rows: Vec<DiffRow> = Vec::new();
+    let (mut added, mut removed, mut lines) = (0usize, 0usize, 0usize);
+    let mut region_start = 0usize;
+
+    // Outline drops unchanged folds (declarations stack quietly); outline+diff
+    // keeps every gap so line-number jumps are always marked.
+    let flush = |rows: &mut Vec<DiffRow>,
+                 added: &mut usize,
+                 removed: &mut usize,
+                 lines: &mut usize,
+                 at: usize| {
+        let changed = *added > 0 || *removed > 0;
+        if *lines > 0 && (changed || expand) {
+            rows.push(DiffRow::Fold {
+                at,
+                lines: *lines,
+                added: *added,
+                removed: *removed,
+            });
+        }
+        *added = 0;
+        *removed = 0;
+        *lines = 0;
+    };
+
+    for (i, dl) in side_by_side.iter().enumerate() {
+        let lnum = if use_old_side {
+            dl.old_line.as_ref().map(|(n, _)| *n)
+        } else {
+            dl.new_line.as_ref().map(|(n, _)| *n)
+        };
+        let is_header = lnum.is_some_and(|n| header_lines.contains(&n));
+        let is_change = !matches!(dl.change_type, ChangeType::Equal);
+        if is_header || (expand && is_change) {
+            // Show this line directly; flush any hidden run before it.
+            flush(&mut rows, &mut added, &mut removed, &mut lines, region_start);
+            region_start = i + 1;
+            rows.push(DiffRow::Code(i));
+        } else {
+            lines += 1;
+            match dl.change_type {
+                ChangeType::Insert => added += 1,
+                ChangeType::Delete => removed += 1,
+                ChangeType::Modified => {
+                    added += 1;
+                    removed += 1;
+                }
+                ChangeType::Equal => {}
+            }
+        }
+    }
+    flush(&mut rows, &mut added, &mut removed, &mut lines, region_start);
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reconstruct each entry's signature line from the source for assertions.
+    fn sigs(source: &str, entries: &[OutlineEntry]) -> Vec<String> {
+        let lines: Vec<&str> = source.lines().collect();
+        entries
+            .iter()
+            .map(|e| lines.get(e.start_row).map(|l| l.trim_end().to_string()).unwrap_or_default())
+            .collect()
+    }
+
+    #[test]
+    fn test_unsupported_language_is_empty() {
+        assert!(compute_outline("some text\nmore", "notes.txt").is_empty());
+    }
+
+    #[test]
+    fn test_empty_source() {
+        assert!(compute_outline("", "main.rs").is_empty());
+    }
+
+    #[test]
+    fn test_rust_functions_and_impl_nesting() {
+        let source = r#"struct Foo {
+    bar: i32,
+}
+
+impl Foo {
+    fn new() -> Self {
+        Self { bar: 0 }
+    }
+
+    fn get(&self) -> i32 {
+        self.bar
+    }
+}
+
+fn free_fn() {}
+"#;
+        let outline = compute_outline(source, "lib.rs");
+        let signatures = sigs(source, &outline);
+
+        for expected in [
+            "struct Foo {",
+            "    bar: i32,",
+            "impl Foo {",
+            "    fn new() -> Self {",
+            "    fn get(&self) -> i32 {",
+            "fn free_fn() {}",
+        ] {
+            assert!(
+                signatures.iter().any(|s| s == expected),
+                "outline should contain {expected:?}, got {signatures:?}"
+            );
+        }
+
+        // The impl encloses its methods (nesting reflected in the line spans).
+        let impl_entry = outline
+            .iter()
+            .find(|e| e.start_row == 4)
+            .expect("impl Foo on row 4");
+        let new_method = outline
+            .iter()
+            .find(|e| e.start_row == 5)
+            .expect("fn new on row 5");
+        assert!(impl_entry.start_row < new_method.start_row && impl_entry.end_row >= new_method.end_row);
+
+        // Entries are returned in source order.
+        let line_numbers: Vec<usize> = outline.iter().map(|e| e.line_number).collect();
+        let mut sorted = line_numbers.clone();
+        sorted.sort_unstable();
+        assert_eq!(line_numbers, sorted);
+    }
+
+    #[test]
+    fn test_typescript_class_with_fields_and_getters() {
+        let source = r#"export class Service {
+    private count: number = 0;
+    readonly name: string;
+
+    constructor() {
+        this.name = "x";
+    }
+
+    get total(): number {
+        return this.count;
+    }
+
+    run(): void {}
+}
+"#;
+        let outline = compute_outline(source, "service.ts");
+        let signatures = sigs(source, &outline);
+
+        assert!(signatures.iter().any(|s| s.contains("class Service")));
+        assert!(signatures.iter().any(|s| s.contains("private count")));
+        assert!(signatures.iter().any(|s| s.contains("readonly name")));
+        assert!(signatures.iter().any(|s| s.contains("constructor(")));
+        assert!(signatures.iter().any(|s| s.contains("get total(")));
+        assert!(signatures.iter().any(|s| s.contains("run(): void")));
+    }
+
+    /// Dev utility: dump the outline for a real file.
+    /// `OUTLINE_FILE=/abs/path.tsx cargo test dump_outline -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn dump_outline() {
+        let path = std::env::var("OUTLINE_FILE").expect("set OUTLINE_FILE");
+        let src = std::fs::read_to_string(&path).expect("read file");
+        let lines: Vec<&str> = src.lines().collect();
+        let outline = compute_outline(&src, &path);
+        println!("\n=== outline of {} ({} entries) ===", path, outline.len());
+        for e in &outline {
+            println!(
+                "{:>5}  {}",
+                e.line_number,
+                lines.get(e.start_row).map(|l| l.trim_end()).unwrap_or("")
+            );
+        }
+    }
+
+    #[test]
+    fn test_tsx_react_arrow_components_and_hooks() {
+        let source = r#"import { useState } from "react";
+
+type Props = { title: string };
+
+export const Card = ({ title }: Props) => {
+    const [open, setOpen] = useState(false);
+    const toggle = () => setOpen((v) => !v);
+    return <div onClick={() => toggle()}>{title}</div>;
+};
+
+export function useCounter() {
+    return 0;
+}
+
+const helper = function () {
+    return 1;
+};
+"#;
+        let outline = compute_outline(source, "Card.tsx");
+        let signatures = sigs(source, &outline);
+
+        // Arrow-function component, its named handler, the function-decl hook,
+        // a function-expression const, and the type alias are all captured.
+        assert!(signatures.iter().any(|s| s.contains("export const Card")));
+        assert!(signatures.iter().any(|s| s.contains("const toggle =")));
+        assert!(signatures.iter().any(|s| s.contains("export function useCounter")));
+        assert!(signatures.iter().any(|s| s.contains("const helper =")));
+        assert!(signatures.iter().any(|s| s.contains("type Props")));
+        // Inline JSX/callback arrows aren't bound to a declarator, so they're
+        // excluded — the outline isn't flooded with anonymous callbacks.
+        assert!(!signatures.iter().any(|s| s.contains("onClick")));
+    }
+
+    #[test]
+    fn test_control_flow_blocks_with_one_liner_threshold() {
+        let source = r#"export function handler(x: number) {
+    if (x < 0) return -1;
+    if (x > 100) {
+        throw new Error("too big");
+    }
+    try {
+        doThing();
+    } catch (e) {
+        log(e);
+    }
+}
+"#;
+        let outline = compute_outline(source, "h.ts");
+        let signatures = sigs(source, &outline);
+
+        // Multi-line control-flow earns a row...
+        assert!(signatures.iter().any(|s| s.contains("if (x > 100)")));
+        assert!(signatures.iter().any(|s| s.trim() == "try {"));
+        // ...but a one-line guard does not (avoids flooding).
+        assert!(!signatures.iter().any(|s| s.contains("if (x < 0)")));
+        // Object-literal methods are not captured (only class methods): the
+        // `fn` line never becomes its own entry, just the enclosing const.
+        let obj_src = "const o = {\n  fn() {\n    return 1;\n  },\n};\n";
+        let obj = compute_outline(obj_src, "o.ts");
+        assert!(obj.iter().all(|e| e.start_row != 1), "object method should not be an entry");
+    }
+
+    #[test]
+    fn test_python_functions_and_classes() {
+        let source = r#"class Greeter:
+    def __init__(self, name):
+        self.name = name
+
+    def greet(self):
+        return self.name
+
+
+def top_level():
+    return 1
+"#;
+        let outline = compute_outline(source, "greet.py");
+        let signatures = sigs(source, &outline);
+
+        assert!(signatures.iter().any(|s| s.contains("class Greeter")));
+        assert!(signatures.iter().any(|s| s.contains("def __init__")));
+        assert!(signatures.iter().any(|s| s.contains("def greet")));
+        assert!(signatures.iter().any(|s| s.contains("def top_level")));
+
+        // The class encloses its methods.
+        let cls = outline.iter().find(|e| e.start_row == 0).expect("class on row 0");
+        let greet = outline
+            .iter()
+            .find(|e| signatures_at(source, e).contains("def greet"))
+            .expect("def greet present");
+        assert!(cls.start_row < greet.start_row && cls.end_row >= greet.end_row);
+    }
+
+    fn signatures_at(source: &str, e: &OutlineEntry) -> String {
+        source.lines().nth(e.start_row).unwrap_or_default().to_string()
+    }
+}

--- a/src/command/diff/render/diff_view.rs
+++ b/src/command/diff/render/diff_view.rs
@@ -9,7 +9,8 @@ use crate::command::diff::annotation::AnnotationEditor;
 use crate::command::diff::context::{compute_context_lines, ContextLine};
 use crate::command::diff::highlight::{highlight_line_spans, FileHighlighter};
 use crate::command::diff::search::{MatchPanel, SearchState};
-use crate::command::diff::state::{Annotation, AnnotationTarget};
+use crate::command::diff::outline::DiffRow;
+use crate::command::diff::state::{Annotation, AnnotationTarget, ViewMode};
 use crate::command::diff::theme;
 
 /// One overlay slot in the rendered diff: either a saved annotation or the
@@ -1031,18 +1032,18 @@ fn is_in_ann_range(
     })
 }
 
-/// Build the focus/annotation indicator span for a diff line.
+/// Build the annotation indicator span for a diff line.
+///
+/// The focused-hunk bar is drawn separately, as a continuous run on the panel's
+/// left border (see the buffer pass after the panels render), so it never lands
+/// in this gutter column and can't fragment across one-sided rows.
 fn make_indicator_span(
-    in_focused: bool,
     in_annotation: bool,
     line_selected: bool,
     bg: Color,
-    focus_style: Style,
     annotation_style: Style,
 ) -> Span<'static> {
-    let indicator = if in_focused {
-        Span::styled("▎", focus_style)
-    } else if in_annotation {
+    let indicator = if in_annotation {
         Span::styled("▍", annotation_style)
     } else {
         Span::styled(" ", Style::default())
@@ -1284,6 +1285,8 @@ pub fn render_diff(
     total_added: usize,
     total_removed: usize,
     editor: Option<&AnnotationEditor>,
+    view_mode: ViewMode,
+    plan: &[DiffRow],
 ) -> (usize, Vec<(usize, usize)>, Vec<(u64, Rect)>, Option<Rect>) {
     let area = frame.area();
     let t = theme::get();
@@ -1396,8 +1399,13 @@ pub fn render_diff(
     // side_by_side is now passed as a parameter (pre-computed and cached)
     let line_stats = compute_line_stats(side_by_side);
 
-    let is_new_file = diff.old_content.is_empty() && !diff.new_content.is_empty();
-    let is_deleted_file = !diff.old_content.is_empty() && diff.new_content.is_empty();
+    // Full mode shows whole added/deleted files with a dedicated single-panel
+    // layout; outline modes always use the unified two-panel plan loop below
+    // (a folded one-sided file renders fine there).
+    let is_new_file =
+        !view_mode.is_outline() && diff.old_content.is_empty() && !diff.new_content.is_empty();
+    let is_deleted_file =
+        !view_mode.is_outline() && !diff.old_content.is_empty() && diff.new_content.is_empty();
 
     // Track how many non-diff rows are at the top (context lines + file annotations)
     let content_row_offset: usize;
@@ -1484,7 +1492,6 @@ pub fn render_diff(
         let line_targets = slot_targets(&line_slots);
         let ann_index_ranges = compute_target_index_ranges(&line_targets, side_by_side);
         let annotation_indicator_style = Style::default().fg(t.ui.highlight);
-        let focus_style = Style::default().fg(t.ui.border_focused);
 
         let row_target_width = (main_area.width as usize).saturating_sub(2) + h_scroll as usize;
 
@@ -1504,11 +1511,9 @@ pub fn render_diff(
             if let Some((num, text)) = &diff_line.new_line {
                 let mut spans: Vec<Span> = Vec::new();
                 spans.push(make_indicator_span(
-                    false,
                     in_annotation,
                     new_line_selected,
                     bg,
-                    focus_style,
                     annotation_indicator_style,
                 ));
 
@@ -1659,7 +1664,6 @@ pub fn render_diff(
         let line_targets = slot_targets(&line_slots);
         let ann_index_ranges = compute_target_index_ranges(&line_targets, side_by_side);
         let annotation_indicator_style = Style::default().fg(t.ui.highlight);
-        let focus_style = Style::default().fg(t.ui.border_focused);
 
         let row_target_width = (main_area.width as usize).saturating_sub(2) + h_scroll as usize;
 
@@ -1679,11 +1683,9 @@ pub fn render_diff(
             if let Some((num, text)) = &diff_line.old_line {
                 let mut spans: Vec<Span> = Vec::new();
                 spans.push(make_indicator_span(
-                    false,
                     in_annotation,
                     old_line_selected,
                     bg,
-                    focus_style,
                     annotation_indicator_style,
                 ));
 
@@ -1766,32 +1768,51 @@ pub fn render_diff(
             );
         }
     } else {
-        let (old_area, new_area) = match diff_fullscreen {
-            DiffFullscreen::OldOnly => (Some(main_area), None),
-            DiffFullscreen::NewOnly => (None, Some(main_area)),
-            DiffFullscreen::None => {
-                let content_chunks = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .split(main_area);
-                (Some(content_chunks[0]), Some(content_chunks[1]))
+        // Outline routes added/deleted files through this two-panel loop too,
+        // but one side would be entirely empty — so collapse to a single panel
+        // (the side with content), matching full mode's added/deleted layout.
+        let content_added = diff.old_content.is_empty() && !diff.new_content.is_empty();
+        let content_deleted = !diff.old_content.is_empty() && diff.new_content.is_empty();
+        let (old_area, new_area) = if view_mode.is_outline() && content_added {
+            (None, Some(main_area))
+        } else if view_mode.is_outline() && content_deleted {
+            (Some(main_area), None)
+        } else {
+            match diff_fullscreen {
+                DiffFullscreen::OldOnly => (Some(main_area), None),
+                DiffFullscreen::NewOnly => (None, Some(main_area)),
+                DiffFullscreen::None => {
+                    let content_chunks = Layout::default()
+                        .direction(Direction::Horizontal)
+                        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                        .split(main_area);
+                    (Some(content_chunks[0]), Some(content_chunks[1]))
+                }
             }
         };
 
-        let old_context = compute_context_lines(
-            &diff.old_content,
-            &diff.filename,
-            scroll as usize,
-            &settings.context,
-            settings.tab_width,
-        );
-        let new_context = compute_context_lines(
-            &diff.new_content,
-            &diff.filename,
-            scroll as usize,
-            &settings.context,
-            settings.tab_width,
-        );
+        // Sticky context headers are a full-diff affordance; in outline modes the
+        // visible declarations already supply structure, so skip them there.
+        let (old_context, new_context) = if view_mode.is_outline() {
+            (Vec::new(), Vec::new())
+        } else {
+            (
+                compute_context_lines(
+                    &diff.old_content,
+                    &diff.filename,
+                    scroll as usize,
+                    &settings.context,
+                    settings.tab_width,
+                ),
+                compute_context_lines(
+                    &diff.new_content,
+                    &diff.filename,
+                    scroll as usize,
+                    &settings.context,
+                    settings.tab_width,
+                ),
+            )
+        };
         let context_count = old_context.len().max(new_context.len());
 
         let reference_area = old_area.or(new_area).unwrap_or(main_area);
@@ -1799,11 +1820,6 @@ pub fn render_diff(
         let scroll_usize = scroll as usize;
 
         let content_height = visible_height.saturating_sub(context_count);
-        let visible_lines: Vec<&DiffLine> = side_by_side
-            .iter()
-            .skip(scroll_usize)
-            .take(content_height)
-            .collect();
 
         let mut old_lines: Vec<Line> = Vec::new();
         let mut new_lines: Vec<Line> = Vec::new();
@@ -1865,19 +1881,6 @@ pub fn render_diff(
             }
         };
 
-        let is_in_focused_hunk = |line_idx: usize, change_type: ChangeType| -> bool {
-            if matches!(change_type, ChangeType::Equal) {
-                return false;
-            }
-            if let Some(hunk_idx) = focused_hunk {
-                if let Some(&hunk_start) = hunks.get(hunk_idx) {
-                    let hunk_end = hunks.get(hunk_idx + 1).copied().unwrap_or(usize::MAX);
-                    return line_idx >= hunk_start && line_idx < hunk_end;
-                }
-            }
-            false
-        };
-
         // Add file-level slots at the top (after context lines)
         for slot in &file_slots {
             let num_lines = slot.height();
@@ -1898,9 +1901,12 @@ pub fn render_diff(
 
         // Track rendered rows for new-panel border annotation markers (paragraph-relative)
         let mut border_marker_rows: Vec<usize> = Vec::new();
+        // Paragraph-relative rows covered by the focused hunk. Drawn afterward as
+        // one continuous bar on the panel's left border, so the indicator is solid
+        // across code and fold rows and never floats on a blank one-sided row.
+        let mut focus_marker_rows: Vec<usize> = Vec::new();
         let mut rendered_row = content_row_offset;
 
-        let focus_style = Style::default().fg(t.ui.border_focused);
         let annotation_indicator_style = Style::default().fg(t.ui.highlight);
 
         // Old panel always has full borders (Borders::ALL); the new panel drops its left
@@ -1917,9 +1923,109 @@ pub fn render_diff(
             .unwrap_or(0)
             + h_scroll as usize;
 
-        for (i, diff_line) in visible_lines.iter().enumerate() {
-            let line_idx = scroll_usize + i;
-            let in_focused = is_in_focused_hunk(line_idx, diff_line.change_type);
+        // One panel's fold marker: tinted "±N" for a changed side, a blank row
+        // for the unchanged side of a one-sided change, and a dim "⋯ N lines"
+        // separator for an unchanged gap (only emitted in outline+diff).
+        let fold_line = |count: usize,
+                         lines: usize,
+                         sign: char,
+                         gutter_fg: Color,
+                         gutter_bg: Color,
+                         line_bg: Color,
+                         changed: bool,
+                         target_width: usize|
+         -> Line<'static> {
+            if !changed {
+                let spans = vec![
+                    Span::styled(" ", Style::default().bg(bg)),
+                    Span::styled(
+                        format!("{:>4} ", "⋯"),
+                        Style::default().fg(t.ui.text_muted).bg(bg),
+                    ),
+                    Span::styled(
+                        format!("{} line{}", lines, if lines == 1 { "" } else { "s" }),
+                        Style::default().fg(t.ui.text_muted).bg(bg),
+                    ),
+                ];
+                return Line::from(pad_line_bg(spans, target_width, bg));
+            }
+            if count == 0 {
+                return blank_diff_line(target_width, bg);
+            }
+            // Match the code-row indicator column (default bg, not the diff tint)
+            // so the gutter's left edge is consistent across code and fold rows.
+            let spans = vec![
+                Span::styled(" ", Style::default()),
+                Span::styled(
+                    format!("{:>4} ", "⋯"),
+                    Style::default().fg(gutter_fg).bg(gutter_bg),
+                ),
+                Span::styled(
+                    format!("{}{}", sign, count),
+                    Style::default().fg(t.ui.text_secondary).bg(line_bg),
+                ),
+            ];
+            Line::from(pad_line_bg(spans, target_width, line_bg))
+        };
+
+        // Side-by-side range of the focused hunk, so the indicator spans every
+        // plan row the hunk touches (its expanded lines and/or the fold hiding
+        // it) rather than a single row.
+        let focused_range = focused_hunk.and_then(|fh| {
+            let start = *hunks.get(fh)?;
+            let end = hunks.get(fh + 1).copied().unwrap_or(usize::MAX);
+            Some((start, end))
+        });
+
+        for (i, row) in plan.iter().skip(scroll_usize).take(content_height).enumerate() {
+            // Fold rows render a marker and carry no per-line diff state.
+            let line_idx = match row {
+                DiffRow::Fold { at, lines, added, removed } => {
+                    let changed = *added > 0 || *removed > 0;
+                    // A fold is in-focus when its hidden range overlaps the hunk.
+                    let next_at = plan
+                        .get(scroll_usize + i + 1)
+                        .map(|r| r.sbs_index())
+                        .unwrap_or(side_by_side.len());
+                    let in_focused =
+                        focused_range.is_some_and(|(s, e)| *at < e && next_at > s);
+                    if in_focused {
+                        focus_marker_rows.push(rendered_row);
+                    }
+                    if old_area.is_some() {
+                        old_lines.push(fold_line(
+                            *removed,
+                            *lines,
+                            '-',
+                            t.diff.deleted_gutter_fg,
+                            t.diff.deleted_gutter_bg,
+                            t.diff.deleted_bg,
+                            changed,
+                            old_row_target_width,
+                        ));
+                    }
+                    if new_area.is_some() {
+                        new_lines.push(fold_line(
+                            *added,
+                            *lines,
+                            '+',
+                            t.diff.added_gutter_fg,
+                            t.diff.added_gutter_bg,
+                            t.diff.added_bg,
+                            changed,
+                            new_row_target_width,
+                        ));
+                    }
+                    rendered_row += 1;
+                    continue;
+                }
+                DiffRow::Code(idx) => *idx,
+            };
+            let diff_line = &side_by_side[line_idx];
+            // A code row joins the focus bar when its side-by-side index falls in
+            // the focused hunk's range — positional, so the bar stays solid across
+            // any aligned context rows the hunk spans rather than breaking on them.
+            let in_focused = focused_range.is_some_and(|(s, e)| line_idx >= s && line_idx < e);
             let hunk_viewed = is_line_in_viewed_hunk(line_idx, diff_line.change_type);
             let mut style = DiffLineStyle::for_change_type(diff_line.change_type, bg, t);
             if hunk_viewed {
@@ -1945,6 +2051,9 @@ pub fn render_diff(
             if new_in_annotation {
                 border_marker_rows.push(rendered_row);
             }
+            if in_focused {
+                focus_marker_rows.push(rendered_row);
+            }
             rendered_row += 1;
 
             let old_line_selected =
@@ -1957,11 +2066,9 @@ pub fn render_diff(
             if old_area.is_some() {
                 let mut old_spans: Vec<Span> = Vec::new();
                 old_spans.push(make_indicator_span(
-                    in_focused,
                     old_in_annotation,
                     old_line_selected,
                     bg,
-                    focus_style,
                     annotation_indicator_style,
                 ));
                 let mut old_line_pushed = false;
@@ -2042,15 +2149,18 @@ pub fn render_diff(
                         old_line_pushed = true;
                     }
                     None => {
-                        // Fill the whole row (including the line-number gutter) with stripes,
-                        // extending past the visible viewport so horizontal scroll stays striped.
-                        let current_len: usize =
-                            old_spans.iter().map(|s| s.content.chars().count()).sum();
-                        let stripe_width = old_row_target_width.saturating_sub(current_len);
-                        old_spans.push(Span::styled(
-                            generate_stripe_pattern(stripe_width),
-                            Style::default().fg(t.diff.empty_placeholder_fg),
-                        ));
+                        // Full diff stripes the empty side of an insert/delete;
+                        // outline modes leave it plain (stripes everywhere would be
+                        // noise when most rows are one-sided).
+                        if !view_mode.is_outline() {
+                            let current_len: usize =
+                                old_spans.iter().map(|s| s.content.chars().count()).sum();
+                            let stripe_width = old_row_target_width.saturating_sub(current_len);
+                            old_spans.push(Span::styled(
+                                generate_stripe_pattern(stripe_width),
+                                Style::default().fg(t.diff.empty_placeholder_fg),
+                            ));
+                        }
                     }
                 }
                 if !old_line_pushed {
@@ -2064,11 +2174,9 @@ pub fn render_diff(
                 let mut new_spans: Vec<Span> = Vec::new();
                 if old_area.is_none() {
                     new_spans.push(make_indicator_span(
-                        in_focused,
                         new_in_annotation,
                         new_line_selected,
                         bg,
-                        focus_style,
                         annotation_indicator_style,
                     ));
                 }
@@ -2150,15 +2258,18 @@ pub fn render_diff(
                         new_line_pushed = true;
                     }
                     None => {
-                        // Fill the whole row (including the line-number gutter) with stripes,
-                        // extending past the visible viewport so horizontal scroll stays striped.
-                        let current_len: usize =
-                            new_spans.iter().map(|s| s.content.chars().count()).sum();
-                        let stripe_width = new_row_target_width.saturating_sub(current_len);
-                        new_spans.push(Span::styled(
-                            generate_stripe_pattern(stripe_width),
-                            Style::default().fg(t.diff.empty_placeholder_fg),
-                        ));
+                        // Full diff stripes the empty side of an insert/delete;
+                        // outline modes leave it plain (stripes everywhere would be
+                        // noise when most rows are one-sided).
+                        if !view_mode.is_outline() {
+                            let current_len: usize =
+                                new_spans.iter().map(|s| s.content.chars().count()).sum();
+                            let stripe_width = new_row_target_width.saturating_sub(current_len);
+                            new_spans.push(Span::styled(
+                                generate_stripe_pattern(stripe_width),
+                                Style::default().fg(t.diff.empty_placeholder_fg),
+                            ));
+                        }
                     }
                 }
                 if !new_line_pushed {
@@ -2221,13 +2332,21 @@ pub fn render_diff(
             }
         }
 
+        let mode_suffix = if view_mode.expands() {
+            " · outline+diff"
+        } else if view_mode.is_outline() {
+            " · outline"
+        } else {
+            ""
+        };
+
         if let Some(area) = old_area {
             let old_para = Paragraph::new(old_lines)
                 .style(Style::default().bg(bg))
                 .scroll((0, h_scroll))
                 .block(
                     Block::default()
-                        .title(Line::styled(" [2] Old ", title_style))
+                        .title(Line::styled(format!(" [2] Old{} ", mode_suffix), title_style))
                         .borders(Borders::ALL)
                         .border_style(border_style),
                 );
@@ -2246,12 +2365,36 @@ pub fn render_diff(
                 .scroll((0, h_scroll))
                 .block(
                     Block::default()
-                        .title(Line::styled(" New ", title_style))
+                        .title(Line::styled(format!(" New{} ", mode_suffix), title_style))
                         .borders(new_borders)
                         .style(Style::default().bg(bg))
                         .border_style(border_style),
                 );
             frame.render_widget(new_para, area);
+        }
+
+        // Draw the focused-hunk bar as one continuous run on the diff's left
+        // border, overwriting the frame edge for exactly the rows the hunk spans.
+        // Keeping it on the border (not in the gutter) means it never collides
+        // with line numbers and stays solid across code and fold rows alike.
+        if let Some(bar_area) = old_area.or(new_area) {
+            if !focus_marker_rows.is_empty() {
+                let border_x = bar_area.x;
+                let content_start = bar_area.y + 1;
+                let bottom = bar_area.y + bar_area.height.saturating_sub(1);
+                let buf = frame.buffer_mut();
+                for &para_row in &focus_marker_rows {
+                    let screen_row = content_start + para_row as u16;
+                    if screen_row < bottom {
+                        if let Some(cell) =
+                            buf.cell_mut(ratatui::layout::Position::new(border_x, screen_row))
+                        {
+                            cell.set_fg(t.ui.border_focused);
+                            cell.set_char('▎');
+                        }
+                    }
+                }
+            }
         }
 
         // Render annotation gutter markers on the shared border for new panel annotations

--- a/src/command/diff/state.rs
+++ b/src/command/diff/state.rs
@@ -3,10 +3,11 @@ use std::time::SystemTime;
 
 use crate::command::diff::diff_algo::{compute_side_by_side, count_added_removed, find_hunk_starts};
 use crate::command::diff::highlight::FileHighlighter;
+use crate::command::diff::outline::{compute_outline, row_plan, DiffRow, OutlineEntry};
 
 use crate::command::diff::search::SearchState;
 use crate::command::diff::types::{
-    build_file_tree, CursorPosition, DiffFullscreen, DiffLine, DiffPanelFocus,
+    build_file_tree, ChangeType, CursorPosition, DiffFullscreen, DiffLine, DiffPanelFocus,
     DiffViewSettings, FileDiff, FocusedPanel, Selection, SelectionMode, SidebarItem,
 };
 use crate::vcs::StackedCommitInfo;
@@ -16,6 +17,41 @@ pub enum PendingKey {
     #[default]
     None,
     G,
+}
+
+/// Which content view the diff panel is showing. Shift+O cycles through them.
+#[derive(Default, Clone, Copy, PartialEq)]
+pub enum ViewMode {
+    /// Normal side-by-side diff (everything).
+    #[default]
+    Diff,
+    /// Folded outline: declaration signatures only; changed bodies become
+    /// `⋯ +N`/`-N` fold markers.
+    Outline,
+    /// Like `Outline`, but the actual changed lines are expanded inline while
+    /// unchanged bodies stay folded away.
+    OutlineExpanded,
+}
+
+impl ViewMode {
+    /// True for either folded view (not the full diff).
+    pub fn is_outline(self) -> bool {
+        matches!(self, ViewMode::Outline | ViewMode::OutlineExpanded)
+    }
+
+    /// True when changed lines should be shown inline rather than counted.
+    pub fn expands(self) -> bool {
+        matches!(self, ViewMode::OutlineExpanded)
+    }
+
+    /// Next mode in the Shift+O cycle.
+    pub fn next(self) -> ViewMode {
+        match self {
+            ViewMode::Diff => ViewMode::Outline,
+            ViewMode::Outline => ViewMode::OutlineExpanded,
+            ViewMode::OutlineExpanded => ViewMode::Diff,
+        }
+    }
 }
 
 fn sidebar_item_path(item: &SidebarItem) -> &str {
@@ -158,6 +194,10 @@ pub struct AppState {
     pub show_sidebar: bool,
     pub settings: DiffViewSettings,
     pub diff_fullscreen: DiffFullscreen,
+    /// Whether the diff panel shows the normal diff or the folded outline.
+    pub view_mode: ViewMode,
+    /// When true, the folded outline shows only declarations touched by the diff.
+    pub outline_changed_only: bool,
     pub search_state: SearchState,
     pub pending_key: PendingKey,
     pub needs_reload: bool,
@@ -194,6 +234,10 @@ pub struct AppState {
     cached_total_lines: Option<(usize, usize)>,
     /// Cached syntax highlighters for current file (avoids re-parsing with tree-sitter every frame)
     cached_highlighters: Option<(usize, FileHighlighter, FileHighlighter)>,
+    /// Cached structural outline for current file (invalidated on file change)
+    cached_outline: Option<(usize, Vec<OutlineEntry>)>,
+    /// Cached row plan for current file, keyed by (file, changed_only, view_mode).
+    cached_plan: Option<(usize, bool, ViewMode, Vec<DiffRow>)>,
     /// Whether search matches need to be recomputed
     search_dirty: bool,
     /// Number of non-content rows at the top of the rendered diff (context lines + file annotations).
@@ -290,6 +334,8 @@ impl AppState {
             show_sidebar: true,
             settings,
             diff_fullscreen: DiffFullscreen::default(),
+            view_mode: ViewMode::default(),
+            outline_changed_only: false,
             search_state: SearchState::default(),
             pending_key: PendingKey::default(),
             needs_reload: false,
@@ -311,6 +357,8 @@ impl AppState {
             cached_hunks: None,
             cached_total_lines: None,
             cached_highlighters: None,
+            cached_outline: None,
+            cached_plan: None,
             search_dirty: true,
             content_row_offset: 0,
             annotation_overlay_gaps: Vec::new(),
@@ -465,12 +513,199 @@ impl AppState {
             .map(|(_, old_hl, new_hl)| (old_hl, new_hl))
     }
 
+    /// Ensure the structural outline for the current file is computed and cached.
+    /// Marks entries as `changed` when their line span intersects a changed hunk.
+    /// Call before using `outline_ref()`.
+    pub fn ensure_outline(&mut self) {
+        if self.file_diffs.is_empty() {
+            return;
+        }
+        let current = self.current_file;
+        let needs_recompute = match &self.cached_outline {
+            Some((cached_file, _)) => *cached_file != current,
+            None => true,
+        };
+        if !needs_recompute {
+            return;
+        }
+
+        // Side-by-side is needed to mark which declarations changed.
+        self.ensure_cache();
+
+        let diff = &self.file_diffs[current];
+        // For deleted files the new side is empty, so outline the old content.
+        let is_deleted = !diff.old_content.is_empty() && diff.new_content.is_empty();
+        let source = if is_deleted {
+            &diff.old_content
+        } else {
+            &diff.new_content
+        };
+        let mut entries = compute_outline(source, &diff.filename);
+
+        // Collect changed source line numbers on the side we're outlining.
+        let mut changed_lines: Vec<usize> = Vec::new();
+        if let Some((_, sbs)) = &self.cached_side_by_side {
+            for dl in sbs {
+                if matches!(dl.change_type, ChangeType::Equal) {
+                    continue;
+                }
+                let ln = if is_deleted {
+                    dl.old_line.as_ref().map(|(n, _)| *n)
+                } else {
+                    dl.new_line.as_ref().map(|(n, _)| *n)
+                };
+                if let Some(n) = ln {
+                    changed_lines.push(n);
+                }
+            }
+        }
+        for entry in &mut entries {
+            let lo = entry.start_row + 1;
+            let hi = entry.end_row + 1;
+            entry.changed = changed_lines.iter().any(|&n| n >= lo && n <= hi);
+        }
+
+        self.cached_outline = Some((current, entries));
+    }
+
+    /// Immutable reference to the cached outline. Call `ensure_outline()` first.
+    pub fn outline_ref(&self) -> &[OutlineEntry] {
+        match &self.cached_outline {
+            Some((_, data)) => data,
+            None => &[],
+        }
+    }
+
+    /// Ensure the row plan for the current file/mode is computed and cached.
+    /// The plan is the single list the renderer and all primitives iterate; a
+    /// view mode only changes which rows it contains. Call before `plan_ref()`.
+    pub fn ensure_plan(&mut self) {
+        if self.file_diffs.is_empty() {
+            return;
+        }
+        let current = self.current_file;
+        let changed_only = self.outline_changed_only;
+        let view_mode = self.view_mode;
+        let needs = match &self.cached_plan {
+            Some((f, co, vm, _)) => *f != current || *co != changed_only || *vm != view_mode,
+            None => true,
+        };
+        if !needs {
+            return;
+        }
+        self.ensure_cache();
+        self.ensure_outline();
+        let is_deleted = {
+            let diff = &self.file_diffs[current];
+            !diff.old_content.is_empty() && diff.new_content.is_empty()
+        };
+        let sbs = self
+            .cached_side_by_side
+            .as_ref()
+            .map(|(_, d)| d.as_slice())
+            .unwrap_or(&[]);
+        let entries = self.outline_ref();
+        let rows = row_plan(view_mode, sbs, entries, is_deleted, changed_only);
+        self.cached_plan = Some((current, changed_only, view_mode, rows));
+    }
+
+    /// Immutable reference to the cached row plan. Call `ensure_plan()` first.
+    pub fn plan_ref(&self) -> &[DiffRow] {
+        match &self.cached_plan {
+            Some((_, _, _, data)) => data,
+            None => &[],
+        }
+    }
+
+    /// The side-by-side index a plan row renders, if it's a code row (folds
+    /// return `None`). Used to map a click to a diff line for starting selection.
+    pub fn sbs_index_for_plan_row(&self, plan_idx: usize) -> Option<usize> {
+        match self.plan_ref().get(plan_idx)? {
+            DiffRow::Code(i) => Some(*i),
+            DiffRow::Fold { .. } => None,
+        }
+    }
+
+    /// Side-by-side index for a plan row, clamped into range and falling back to
+    /// a fold's anchor line. Used while dragging a selection (always needs a line).
+    pub fn sbs_index_for_plan_row_clamped(&self, plan_idx: usize) -> usize {
+        let plan = self.plan_ref();
+        if plan.is_empty() {
+            return 0;
+        }
+        plan[plan_idx.min(plan.len() - 1)].sbs_index()
+    }
+
+    /// Map a 1-based source line number to its side-by-side index (exact match
+    /// on either side, else the closest preceding line).
+    pub fn sbs_index_for_line(&self, line: usize) -> Option<usize> {
+        let sbs = self.side_by_side_ref();
+        let mut best = None;
+        for (i, dl) in sbs.iter().enumerate() {
+            for side in [dl.new_line.as_ref(), dl.old_line.as_ref()].into_iter().flatten() {
+                if side.0 == line {
+                    return Some(i);
+                }
+                if side.0 < line {
+                    best = Some(i);
+                }
+            }
+        }
+        best
+    }
+
+    /// The source line (new side preferred) of the currently focused hunk, used
+    /// as a stable anchor when switching view modes. `None` if no hunk is focused.
+    pub fn focused_hunk_line(&self) -> Option<usize> {
+        let fh = self.focused_hunk?;
+        let idx = *self.hunks_ref().get(fh)?;
+        let dl = self.side_by_side_ref().get(idx)?;
+        dl.new_line
+            .as_ref()
+            .map(|(n, _)| *n)
+            .or_else(|| dl.old_line.as_ref().map(|(n, _)| *n))
+    }
+
+    /// Plan-row index for a side-by-side index. In full mode the plan is 1:1, so
+    /// this is the identity; in outline modes it finds the row (code or fold)
+    /// that represents the line.
+    pub fn active_row_for_sbs(&mut self, sbs_idx: usize) -> usize {
+        if !self.view_mode.is_outline() {
+            return sbs_idx;
+        }
+        self.ensure_plan();
+        let mut best = 0;
+        for (ri, row) in self.plan_ref().iter().enumerate() {
+            if row.sbs_index() <= sbs_idx {
+                best = ri;
+            } else {
+                break;
+            }
+        }
+        best
+    }
+
+    /// Row index of `line` within the active view's row list. Used to keep the
+    /// focused hunk pinned at the same screen height across a mode switch.
+    pub fn active_row_for_line(&mut self, line: usize) -> usize {
+        let target = self.sbs_index_for_line(line).unwrap_or(0);
+        self.active_row_for_sbs(target)
+    }
+
+    /// Number of rows in the active view (the plan length). Used to clamp scroll.
+    pub fn active_line_count(&mut self) -> usize {
+        self.ensure_plan();
+        self.plan_ref().len()
+    }
+
     /// Invalidate the cache (call when file changes)
     pub fn invalidate_cache(&mut self) {
         self.cached_side_by_side = None;
         self.cached_hunks = None;
         self.cached_total_lines = None;
         self.cached_highlighters = None;
+        self.cached_outline = None;
+        self.cached_plan = None;
         self.search_dirty = true;
         self.content_row_offset = 0;
         self.annotation_overlay_gaps.clear();
@@ -804,14 +1039,17 @@ impl AppState {
         self.clear_selection(); // Clear selection when changing files
         self.invalidate_cache(); // Clear cache for new file
 
-        // Use cached computation
-        let hunks = self.get_hunks().to_vec();
-        self.scroll = hunks
-            .first()
-            .map(|&h| (h as u16).saturating_sub(5))
-            .unwrap_or(0);
+        let first_hunk = self.get_hunks().first().copied();
+        self.focused_hunk = if first_hunk.is_some() { Some(0) } else { None };
         self.h_scroll = 0;
-        self.focused_hunk = if hunks.is_empty() { None } else { Some(0) };
+        // Scroll to the first hunk in the active view's coordinate space: plan
+        // rows in outline modes, side-by-side indices in full diff. Without this
+        // mapping, outline mode would scroll past the (much shorter) plan and
+        // show an empty panel.
+        self.scroll = match first_hunk {
+            Some(h) => (self.active_row_for_sbs(h) as u16).saturating_sub(5),
+            None => 0,
+        };
     }
 
     /// Get annotation by id
@@ -1027,5 +1265,76 @@ mod tests {
 
         assert_eq!(state.current_file, 0);
         assert!(state.file_diffs.is_empty());
+    }
+
+    #[test]
+    fn test_outline_marks_changed_declarations_and_folds() {
+        use crate::command::diff::outline::DiffRow;
+        let old_content = "fn unchanged() {\n    let x = 1;\n}\n\nfn changed() {\n    let y = 2;\n}\n";
+        let new_content = "fn unchanged() {\n    let x = 1;\n}\n\nfn changed() {\n    let y = 99;\n}\n";
+        let diffs = vec![FileDiff {
+            filename: "lib.rs".to_string(),
+            old_content: old_content.to_string(),
+            new_content: new_content.to_string(),
+            status: FileStatus::Modified,
+            is_binary: false,
+        }];
+
+        let mut state = AppState::new(diffs, None);
+        state.ensure_outline();
+
+        // `fn unchanged` starts on line 1 (row 0), `fn changed` on line 5 (row 4).
+        let changed_flag = state
+            .outline_ref()
+            .iter()
+            .find(|e| e.line_number == 5)
+            .expect("changed fn should appear in outline")
+            .changed;
+        let unchanged_flag = state
+            .outline_ref()
+            .iter()
+            .find(|e| e.line_number == 1)
+            .expect("unchanged fn should appear in outline")
+            .changed;
+
+        assert!(changed_flag, "modified function should be marked changed");
+        assert!(
+            !unchanged_flag,
+            "untouched function should not be marked changed"
+        );
+
+        // Outline plan keeps both fn signatures as Code rows and collapses the
+        // bodies into Fold rows; the changed body's fold reports an addition.
+        state.view_mode = ViewMode::Outline;
+        state.ensure_plan();
+        let code_rows = state
+            .plan_ref()
+            .iter()
+            .filter(|r| matches!(r, DiffRow::Code(_)))
+            .count();
+        assert!(code_rows >= 2, "both fn signatures should remain visible");
+        let has_changed_fold = state
+            .plan_ref()
+            .iter()
+            .any(|r| matches!(r, DiffRow::Fold { added, removed, .. } if *added > 0 || *removed > 0));
+        assert!(has_changed_fold, "a fold should report the hidden change");
+
+        // changed-only narrows the visible declarations.
+        let full_code = code_rows;
+        state.outline_changed_only = true;
+        state.ensure_plan();
+        let changed_code = state
+            .plan_ref()
+            .iter()
+            .filter(|r| matches!(r, DiffRow::Code(_)))
+            .count();
+        assert!(changed_code < full_code, "changed-only should hide the untouched fn");
+
+        // Full-diff plan is 1:1 with the side-by-side lines.
+        state.view_mode = ViewMode::Diff;
+        state.outline_changed_only = false;
+        state.ensure_plan();
+        assert!(state.plan_ref().iter().all(|r| matches!(r, DiffRow::Code(_))));
+        assert_eq!(state.plan_ref().len(), state.total_lines());
     }
 }


### PR DESCRIPTION
## What

Adds an **outline view** to `lumen diff`, cycled with **Shift+O** across three modes:

1. **Full diff** — unchanged.
2. **Outline** — declarations only; changed bodies collapse to tinted `±N` folds.
3. **Outline+diff** — changed lines expand inline; every gap between them shows a `⋯ N lines` fold marker.

Outline is a *folding* of the real two-sided diff, not a separate view: green/red backgrounds, syntax highlighting, scroll, hunk focus, annotations, selection, and in-file search all keep working in every mode.

## How

Modes are thin **adapters** over a single *row plan*. `DiffRow::Code(idx) | Fold{..}` is one coordinate space, and `row_plan(view_mode, …)` is the only place modes differ. The renderer and every primitive operate on the plan, so each mode behaves uniformly by construction instead of re-deriving features per path (the old parallel `render_folded` renderer is gone).

Outline structure is extracted with per-language tree-sitter queries (Rust, TS/TSX/JS, Python, Go, C#): top-level declarations plus non-trivial control-flow blocks (`if`/`for`/`while`/`switch`/`try`, filtered by a minimum span) so imperative files like route handlers show a navigable skeleton rather than just a signature.

The focused-hunk indicator is drawn as one continuous bar on the diff's **left border**, off the line-number gutter, so it stays solid across both code and fold rows.

## Test plan

- `cargo test` — outline + state unit tests pass (46 diff tests green).
- `cargo clippy` — holds at the existing baseline, no new warnings.
- Verified live (tmux) across all three modes: scroll, `{`/`}` hunk nav with the indicator pinned on mode switch, annotations, selection, and search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)