### PR TITLE
perf: fix performance degradation with sticky scroll context

### DIFF
--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -445,6 +445,7 @@ fn run_app_internal(
                     frame,
                     diff,
                     &state.file_diffs,
+                    &state.cached_trees,
                     &state.sidebar_items,
                     &state.sidebar_visible,
                     &state.collapsed_dirs,

--- a/src/command/diff/context.rs
+++ b/src/command/diff/context.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use once_cell::sync::Lazy;
 use streaming_iterator::StreamingIterator;
-use tree_sitter::{Language, Parser, Query, QueryCursor};
+use tree_sitter::{Language, Point, Query, QueryCursor, Tree};
 
 /// Configuration for context lines feature
 #[derive(Clone)]
@@ -118,8 +118,8 @@ const CSHARP_CONTEXT_QUERY: &str = r#"
 (lock_statement) @context
 "#;
 
-struct LanguageContext {
-    language: Language,
+pub struct LanguageContext {
+    pub language: Language,
     query: Query,
 }
 
@@ -224,7 +224,7 @@ static LANGUAGE_CONTEXTS: Lazy<Vec<(&'static str, LanguageContext)>> = Lazy::new
     contexts
 });
 
-fn get_language_context(filename: &str) -> Option<&'static LanguageContext> {
+pub fn get_language_context(filename: &str) -> Option<&'static LanguageContext> {
     let ext = Path::new(filename).extension().and_then(|e| e.to_str())?;
     LANGUAGE_CONTEXTS
         .iter()
@@ -240,6 +240,7 @@ fn get_language_context(filename: &str) -> Option<&'static LanguageContext> {
 pub fn compute_context_lines(
     source: &str,
     filename: &str,
+    trees: &HashMap<String, Tree>,
     scroll_position: usize,
     config: &ContextConfig,
     tab_width: usize,
@@ -254,16 +255,15 @@ pub fn compute_context_lines(
         return Vec::new();
     };
 
-    let mut parser = Parser::new();
-    if parser.set_language(&lang_ctx.language).is_err() {
-        return Vec::new();
-    }
-
-    let Some(tree) = parser.parse(source, None) else {
+    let Some(tree) = trees.get(filename) else {
         return Vec::new();
     };
 
     let mut cursor = QueryCursor::new();
+
+    let start_point = Point::new(0, 0);
+    let end_point = Point::new(scroll_position, 0);
+    cursor.set_point_range(start_point..end_point);
 
     let lines: Vec<&str> = source.lines().collect();
 
@@ -313,33 +313,66 @@ pub fn compute_context_lines(
 
 #[cfg(test)]
 mod tests {
+    use tree_sitter::Parser;
+
     use super::*;
+
+    fn get_tree_cache(filename: &str, source: &str) -> HashMap<String, Tree> {
+        let mut tree_cache = HashMap::default();
+        
+        let Some(lang_ctx) = get_language_context(&filename) else {
+            return tree_cache;
+        };
+        
+        let mut parser = Parser::new();
+        if parser.set_language(&lang_ctx.language).is_err() {
+            return tree_cache;
+        }
+        
+        if let Some(tree) = parser.parse(source, None) {
+            tree_cache.insert(filename.to_string(), tree);
+        }
+
+        return tree_cache;
+
+    }
 
     #[test]
     fn test_empty_source() {
         let config = ContextConfig::default();
-        let result = compute_context_lines("", "test.rs", 5, &config, 4);
+        let filename = "test.rs";
+        let source = "";
+        let tree_cache = get_tree_cache(filename, source);
+        
+        let result = compute_context_lines(source, filename, &tree_cache, 5, &config, 4);
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_scroll_at_zero() {
         let config = ContextConfig::default();
+        let filename = "test.rs";
         let source = "fn main() {\n    println!(\"hello\");\n}";
-        let result = compute_context_lines(source, "test.rs", 0, &config, 4);
+        let tree_cache = get_tree_cache(filename, source);
+        
+        let result = compute_context_lines(source, filename, &tree_cache, 0, &config, 4);
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_rust_function_context() {
         let config = ContextConfig::default();
+        let filename = "test.rs";
         let source = r#"fn main() {
     let x = 1;
     let y = 2;
     let z = 3;
     println!("{}", x + y + z);
 }"#;
-        let result = compute_context_lines(source, "test.rs", 3, &config, 4);
+        let tree_cache = get_tree_cache(filename, source);
+
+        
+        let result = compute_context_lines(source, filename, &tree_cache, 3, &config, 4);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].content, "fn main() {");
         assert_eq!(result[0].line_number, 1);
@@ -348,6 +381,7 @@ mod tests {
     #[test]
     fn test_nested_rust_contexts() {
         let config = ContextConfig::default();
+        let filename = "test.rs";
         let source = r#"impl Foo {
     fn bar() {
         if true {
@@ -355,7 +389,9 @@ mod tests {
         }
     }
 }"#;
-        let result = compute_context_lines(source, "test.rs", 3, &config, 4);
+        let tree_cache = get_tree_cache(filename, source);
+        
+        let result = compute_context_lines(source, filename, &tree_cache, 3, &config, 4);
         // Should show impl, fn, and if
         assert!(result.len() >= 2);
         assert!(result[0].content.contains("impl Foo"));
@@ -364,8 +400,11 @@ mod tests {
     #[test]
     fn test_unsupported_language() {
         let config = ContextConfig::default();
+        let filename = "test.xyz";
         let source = "some content\nmore content\neven more";
-        let result = compute_context_lines(source, "test.xyz", 2, &config, 4);
+        let tree_cache = get_tree_cache(filename, source);
+        
+        let result = compute_context_lines(source, filename, &tree_cache, 2, &config, 4);
         assert!(result.is_empty());
     }
 
@@ -375,8 +414,11 @@ mod tests {
             enabled: false,
             max_lines: 5,
         };
+        let filename = "test.rs";
         let source = "fn main() {\n    let x = 1;\n}";
-        let result = compute_context_lines(source, "test.rs", 1, &config, 4);
+        let tree_cache = get_tree_cache(filename, source);
+        
+        let result = compute_context_lines(source, filename, &tree_cache, 1, &config, 4);
         assert!(result.is_empty());
     }
 }

--- a/src/command/diff/render/diff_view.rs
+++ b/src/command/diff/render/diff_view.rs
@@ -5,12 +5,12 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
-use crate::command::diff::annotation::AnnotationEditor;
 use crate::command::diff::context::{compute_context_lines, ContextLine};
 use crate::command::diff::highlight::{highlight_line_spans, FileHighlighter};
 use crate::command::diff::search::{MatchPanel, SearchState};
 use crate::command::diff::state::{Annotation, AnnotationTarget};
 use crate::command::diff::theme;
+use crate::command::diff::{annotation::AnnotationEditor, state::TreeCache};
 
 /// One overlay slot in the rendered diff: either a saved annotation or the
 /// active inline editor (new or editing an existing annotation).
@@ -1249,6 +1249,7 @@ pub fn render_diff(
     frame: &mut Frame,
     diff: &FileDiff,
     _file_diffs: &[FileDiff],
+    trees: &TreeCache,
     sidebar_items: &[SidebarItem],
     sidebar_visible: &[usize],
     collapsed_dirs: &HashSet<String>,
@@ -1420,6 +1421,7 @@ pub fn render_diff(
         let new_context = compute_context_lines(
             &diff.new_content,
             &diff.filename,
+            &trees.new_file_trees,
             scroll as usize,
             &settings.context,
             settings.tab_width,
@@ -1595,6 +1597,7 @@ pub fn render_diff(
         let old_context = compute_context_lines(
             &diff.old_content,
             &diff.filename,
+            &trees.old_file_trees,
             scroll as usize,
             &settings.context,
             settings.tab_width,
@@ -1781,6 +1784,7 @@ pub fn render_diff(
         let old_context = compute_context_lines(
             &diff.old_content,
             &diff.filename,
+            &trees.old_file_trees,
             scroll as usize,
             &settings.context,
             settings.tab_width,
@@ -1788,6 +1792,7 @@ pub fn render_diff(
         let new_context = compute_context_lines(
             &diff.new_content,
             &diff.filename,
+            &trees.new_file_trees,
             scroll as usize,
             &settings.context,
             settings.tab_width,

--- a/src/command/diff/state.rs
+++ b/src/command/diff/state.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::time::SystemTime;
 
+use tree_sitter::{Parser, Tree};
+
+use crate::command::diff::context::get_language_context;
 use crate::command::diff::diff_algo::{compute_side_by_side, count_added_removed, find_hunk_starts};
 use crate::command::diff::highlight::FileHighlighter;
 
@@ -139,6 +142,12 @@ impl Annotation {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct TreeCache {
+    pub old_file_trees: HashMap<String, Tree>,
+    pub new_file_trees: HashMap<String, Tree>,
+}
+
 pub struct AppState {
     pub file_diffs: Vec<FileDiff>,
     pub sidebar_items: Vec<SidebarItem>,
@@ -194,6 +203,8 @@ pub struct AppState {
     cached_total_lines: Option<(usize, usize)>,
     /// Cached syntax highlighters for current file (avoids re-parsing with tree-sitter every frame)
     cached_highlighters: Option<(usize, FileHighlighter, FileHighlighter)>,
+    /// Cached parsed syntax tree
+    pub cached_trees: TreeCache,
     /// Whether search matches need to be recomputed
     search_dirty: bool,
     /// Number of non-content rows at the top of the rendered diff (context lines + file annotations).
@@ -311,6 +322,7 @@ impl AppState {
             cached_hunks: None,
             cached_total_lines: None,
             cached_highlighters: None,
+            cached_trees: TreeCache::default(),
             search_dirty: true,
             content_row_offset: 0,
             annotation_overlay_gaps: Vec::new(),
@@ -354,6 +366,25 @@ impl AppState {
             self.cached_side_by_side = Some((current, side_by_side));
             self.cached_hunks = Some((current, hunks));
             self.cached_total_lines = Some((current, total));
+            let filename = self.file_diffs[current].filename.clone();
+            let old_source = &self.file_diffs[current].old_content;
+            let new_source = &self.file_diffs[current].new_content;
+            let Some(lang_ctx) = get_language_context(&filename) else {
+                return &self.cached_side_by_side.as_ref().unwrap().1;
+            };
+            let mut parser = Parser::new();
+            if parser.set_language(&lang_ctx.language).is_ok() {
+                let old_tree = self.cached_trees.old_file_trees.get(&filename);
+                if let Some(tree) = parser.parse(old_source, old_tree) {
+                    self.cached_trees
+                        .old_file_trees
+                        .insert(filename.clone(), tree);
+                }
+                let new_tree = self.cached_trees.new_file_trees.get(&filename);
+                if let Some(tree) = parser.parse(new_source, new_tree) {
+                    self.cached_trees.new_file_trees.insert(filename, tree);
+                }
+            }
         }
 
         &self.cached_side_by_side.as_ref().unwrap().1
@@ -389,6 +420,25 @@ impl AppState {
             self.cached_side_by_side = Some((current, sbs));
             self.cached_hunks = Some((current, hnks));
             self.cached_total_lines = Some((current, total));
+            let filename = self.file_diffs[current].filename.clone();
+            let old_source = &self.file_diffs[current].old_content;
+            let new_source = &self.file_diffs[current].new_content;
+            let Some(lang_ctx) = get_language_context(&filename) else {
+                return;
+            };
+            let mut parser = Parser::new();
+            if parser.set_language(&lang_ctx.language).is_ok() {
+                let old_tree = self.cached_trees.old_file_trees.get(&filename);
+                if let Some(tree) = parser.parse(old_source, old_tree) {
+                    self.cached_trees
+                        .old_file_trees
+                        .insert(filename.clone(), tree);
+                }
+                let new_tree = self.cached_trees.new_file_trees.get(&filename);
+                if let Some(tree) = parser.parse(new_source, new_tree) {
+                    self.cached_trees.new_file_trees.insert(filename, tree);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
closes #171

- compute_context_lines now receives a HashMap of already-parsed syntax trees instead of parsing the file on every call.
- The tree-sitter query range is now scoped from the start of the file to the current scroll position, avoiding evaluation of nodes below the visible viewport.