### PR TITLE
Support non-git diffs from stdin or two files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,6 +2553,7 @@ dependencies = [
  "indoc",
  "inquire",
  "jj-lib",
+ "libc",
  "notify",
  "notify-debouncer-mini",
  "nucleo-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ pollster = { version = "0.4", optional = true }
 futures = { version = "0.3", optional = true }
 terminal-light = "1.8.0"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 default = ["jj"]
 jj = ["jj-lib", "chrono", "pollster", "futures"]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,20 @@ lumen diff --focus src/main.rs
 
 # Soft-wrap long lines (also settable in lumen.config.json)
 lumen diff --wrap
+
+# Review a unified diff from any tool, no repository required
+arc diff | lumen diff --stdin
+kubectl diff -f manifest.yaml | lumen diff --stdin
+lumen diff -            # `-` is shorthand for --stdin
+
+# Compare two arbitrary files directly
+lumen diff --files old.toml new.toml
 ```
+
+> `--stdin` reconstructs the diff from the hunks in the patch, so the view shows
+> the changed regions and their context (what the patch carried), not the whole
+> file. This makes lumen a general-purpose diff viewer for `arc`, `chezmoi`,
+> `kubectl`, `terraform`, and any tool that emits a unified diff.
 
 #### Stacked Diff Mode
 

--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -35,6 +35,33 @@ fn open_tui_writer() -> io::Result<Box<dyn Write + Send>> {
     Ok(Box::new(io::stdout()))
 }
 
+struct TerminalGuard {
+    armed: bool,
+}
+
+impl TerminalGuard {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let _ = disable_raw_mode();
+        if let Ok(mut out) = open_tui_writer() {
+            let _ = execute!(
+                out,
+                PopKeyboardEnhancementFlags,
+                DisableMouseCapture,
+                LeaveAlternateScreen
+            );
+        }
+    }
+}
+
 use super::annotation::{AnnotationEditor, AnnotationEditorResult};
 use super::coordinates::{extract_selected_text, PanelLayout};
 use super::git::{
@@ -270,6 +297,15 @@ pub fn run_app(
     run_app_internal(options, pr_info, file_diffs, None, backend)
 }
 
+pub fn run_app_external(
+    mut options: DiffOptions,
+    file_diffs: Vec<super::types::FileDiff>,
+    backend: &dyn VcsBackend,
+) -> io::Result<()> {
+    options.watch = false;
+    run_app_internal(options, None, file_diffs, None, backend)
+}
+
 pub fn run_app_stacked(
     options: DiffOptions,
     commits: Vec<StackedCommitInfo>,
@@ -344,6 +380,7 @@ fn run_app_internal(
     // Now enter TUI mode. Use /dev/tty when stdout is captured so the
     // alternate-screen escapes go to the real terminal, not the pipe.
     enable_raw_mode()?;
+    let mut terminal_guard = TerminalGuard { armed: true };
     let mut tui_writer = open_tui_writer()?;
     execute!(tui_writer, EnterAlternateScreen, EnableMouseCapture)?;
     // Opt into the kitty keyboard protocol so terminals that support it
@@ -439,7 +476,8 @@ fn run_app_internal(
             let row_offset = std::cell::Cell::new(0usize);
             let gaps_cell = std::cell::RefCell::new(Vec::new());
             let rects_cell = std::cell::RefCell::new(Vec::new());
-            let editor_rect_cell: std::cell::Cell<Option<ratatui::layout::Rect>> = std::cell::Cell::new(None);
+            let editor_rect_cell: std::cell::Cell<Option<ratatui::layout::Rect>> =
+                std::cell::Cell::new(None);
             terminal.draw(|frame| {
                 let (offset, gaps, rects, er) = render_diff(
                     frame,
@@ -1899,10 +1937,8 @@ fn run_app_internal(
                         }
                         KeyCode::Char('e') => {
                             if !state.file_diffs.is_empty() {
-                                let _ = execute!(
-                                    terminal.backend_mut(),
-                                    PopKeyboardEnhancementFlags
-                                );
+                                let _ =
+                                    execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
                                 execute!(
                                     terminal.backend_mut(),
                                     DisableMouseCapture,
@@ -1951,7 +1987,9 @@ fn run_app_internal(
                                 )?;
                                 let _ = execute!(
                                     terminal.backend_mut(),
-                                    PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+                                    PushKeyboardEnhancementFlags(
+                                        KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                                    )
                                 );
                                 terminal.clear()?;
                             }
@@ -2105,10 +2143,10 @@ fn run_app_internal(
                                                 key: "h/l or left/right",
                                                 description: "Scroll horizontally",
                                             },
-                                        KeyBind {
-                                            key: "w",
-                                            description: "Toggle watch mode",
-                                        },
+                                            KeyBind {
+                                                key: "w",
+                                                description: "Toggle watch mode",
+                                            },
                                             KeyBind {
                                                 key: "gg / G",
                                                 description: "Scroll to top / bottom",
@@ -2152,7 +2190,8 @@ fn run_app_internal(
                                             },
                                             KeyBind {
                                                 key: "ctrl+f",
-                                                description: "Global fuzzy search (all files, with preview)",
+                                                description:
+                                                    "Global fuzzy search (all files, with preview)",
                                             },
                                             KeyBind {
                                                 key: "n or down",
@@ -2200,6 +2239,7 @@ fn run_app_internal(
         }
     }
 
+    terminal_guard.disarm();
     let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
     execute!(
         terminal.backend_mut(),

--- a/src/command/diff/external.rs
+++ b/src/command/diff/external.rs
@@ -422,4 +422,56 @@ Binary files a/img.png and b/img.png differ
         let paths = vec!["a".to_string(), "b".to_string(), "c".to_string()];
         assert!(load_files_diffs(&paths).is_err());
     }
+
+    #[test]
+    fn test_load_files_diffs_modified() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = dir.path().join("old.txt");
+        let new = dir.path().join("new.txt");
+        std::fs::write(&old, "one\n").unwrap();
+        std::fs::write(&new, "two\n").unwrap();
+
+        let paths = vec![
+            old.to_string_lossy().into_owned(),
+            new.to_string_lossy().into_owned(),
+        ];
+        let diffs = load_files_diffs(&paths).unwrap();
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].filename, paths[1]);
+        assert_eq!(diffs[0].status, FileStatus::Modified);
+        assert_eq!(diffs[0].old_content, "one\n");
+        assert_eq!(diffs[0].new_content, "two\n");
+    }
+
+    #[test]
+    fn test_load_files_diffs_added_when_old_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let new = dir.path().join("new.txt");
+        std::fs::write(&new, "hello\n").unwrap();
+
+        let paths = vec![
+            dir.path().join("absent.txt").to_string_lossy().into_owned(),
+            new.to_string_lossy().into_owned(),
+        ];
+        let diffs = load_files_diffs(&paths).unwrap();
+        assert_eq!(diffs[0].status, FileStatus::Added);
+        assert!(diffs[0].old_content.is_empty());
+        assert_eq!(diffs[0].new_content, "hello\n");
+    }
+
+    #[test]
+    fn test_load_files_diffs_deleted_when_new_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = dir.path().join("old.txt");
+        std::fs::write(&old, "bye\n").unwrap();
+
+        let paths = vec![
+            old.to_string_lossy().into_owned(),
+            dir.path().join("absent.txt").to_string_lossy().into_owned(),
+        ];
+        let diffs = load_files_diffs(&paths).unwrap();
+        assert_eq!(diffs[0].status, FileStatus::Deleted);
+        assert_eq!(diffs[0].old_content, "bye\n");
+        assert!(diffs[0].new_content.is_empty());
+    }
 }

--- a/src/command/diff/external.rs
+++ b/src/command/diff/external.rs
@@ -1,0 +1,425 @@
+use std::fs;
+use std::io::Read;
+
+use super::types::{is_binary_content, FileDiff, FileStatus};
+
+const DEV_NULL: &str = "/dev/null";
+
+pub fn load_stdin_diffs() -> Result<Vec<FileDiff>, String> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .map_err(|e| format!("Failed to read diff from stdin: {}", e))?;
+
+    if input.trim().is_empty() {
+        return Err("No diff received on stdin".to_string());
+    }
+
+    let diffs = parse_unified_diff(&input);
+    if diffs.is_empty() {
+        return Err("Could not parse any file diffs from stdin input".to_string());
+    }
+
+    reconnect_stdin_to_tty();
+
+    Ok(diffs)
+}
+
+#[cfg(unix)]
+fn reconnect_stdin_to_tty() {
+    use std::os::unix::io::AsRawFd;
+
+    for fd in [libc::STDOUT_FILENO, libc::STDERR_FILENO] {
+        unsafe {
+            if libc::isatty(fd) == 1 {
+                libc::dup2(fd, libc::STDIN_FILENO);
+                return;
+            }
+        }
+    }
+
+    if let Ok(tty) = fs::OpenOptions::new().read(true).write(true).open("/dev/tty") {
+        unsafe {
+            libc::dup2(tty.as_raw_fd(), libc::STDIN_FILENO);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn reconnect_stdin_to_tty() {}
+
+pub fn load_files_diffs(paths: &[String]) -> Result<Vec<FileDiff>, String> {
+    match paths.len() {
+        2 => {
+            let old_content = read_file_or_empty(&paths[0])?;
+            let new_content = read_file_or_empty(&paths[1])?;
+
+            let status = if old_content.is_empty() && !new_content.is_empty() {
+                FileStatus::Added
+            } else if !old_content.is_empty() && new_content.is_empty() {
+                FileStatus::Deleted
+            } else {
+                FileStatus::Modified
+            };
+
+            let is_binary = is_binary_content(&old_content) || is_binary_content(&new_content);
+
+            Ok(vec![FileDiff {
+                filename: paths[1].clone(),
+                old_content,
+                new_content,
+                status,
+                is_binary,
+            }])
+        }
+        3 => Err(
+            "Three-file (diff3/merge) mode is not supported yet. Use two files or --stdin."
+                .to_string(),
+        ),
+        n => Err(format!(
+            "--files expects 2 paths (old new), got {}. Three-way merge is not supported yet.",
+            n
+        )),
+    }
+}
+
+fn read_file_or_empty(path: &str) -> Result<String, String> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(String::from_utf8_lossy(&bytes).into_owned()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(format!("Failed to read {}: {}", path, e)),
+    }
+}
+
+struct FileAcc {
+    old_path: String,
+    new_path: String,
+    old_content: String,
+    new_content: String,
+    is_binary: bool,
+    saw_hunk: bool,
+}
+
+impl FileAcc {
+    fn new(old_path: String, new_path: String) -> Self {
+        Self {
+            old_path,
+            new_path,
+            old_content: String::new(),
+            new_content: String::new(),
+            is_binary: false,
+            saw_hunk: false,
+        }
+    }
+
+    fn is_pristine(&self) -> bool {
+        !self.saw_hunk
+            && !self.is_binary
+            && self.old_content.is_empty()
+            && self.new_content.is_empty()
+    }
+
+    fn build(self) -> FileDiff {
+        let filename = if self.new_path == DEV_NULL {
+            self.old_path.clone()
+        } else {
+            self.new_path.clone()
+        };
+
+        let status = if self.old_path == DEV_NULL {
+            FileStatus::Added
+        } else if self.new_path == DEV_NULL {
+            FileStatus::Deleted
+        } else {
+            FileStatus::Modified
+        };
+
+        let is_binary = self.is_binary
+            || is_binary_content(&self.old_content)
+            || is_binary_content(&self.new_content);
+
+        FileDiff {
+            filename,
+            old_content: self.old_content,
+            new_content: self.new_content,
+            status,
+            is_binary,
+        }
+    }
+}
+
+pub fn parse_unified_diff(input: &str) -> Vec<FileDiff> {
+    let lines: Vec<&str> = input.lines().collect();
+    let mut files: Vec<FileDiff> = Vec::new();
+    let mut cur: Option<FileAcc> = None;
+
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+
+        if let Some((a, b)) = parse_diff_git_header(line) {
+            if let Some(acc) = cur.take() {
+                files.push(acc.build());
+            }
+            cur = Some(FileAcc::new(a, b));
+            i += 1;
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix("--- ") {
+            if i + 1 < lines.len() {
+                if let Some(new_rest) = lines[i + 1].strip_prefix("+++ ") {
+                    let old_path = parse_header_path(rest);
+                    let new_path = parse_header_path(new_rest);
+                    match cur.as_mut() {
+                        Some(acc) if acc.is_pristine() => {
+                            acc.old_path = old_path;
+                            acc.new_path = new_path;
+                        }
+                        _ => {
+                            if let Some(acc) = cur.take() {
+                                files.push(acc.build());
+                            }
+                            cur = Some(FileAcc::new(old_path, new_path));
+                        }
+                    }
+                    i += 2;
+                    continue;
+                }
+            }
+        }
+
+        if line.starts_with("Binary files ") || line.starts_with("GIT binary patch") {
+            if let Some(acc) = cur.as_mut() {
+                acc.is_binary = true;
+            }
+            i += 1;
+            continue;
+        }
+
+        if line.starts_with("@@") {
+            if let Some(acc) = cur.as_mut() {
+                acc.saw_hunk = true;
+            }
+            i += 1;
+            continue;
+        }
+
+        if let Some(acc) = cur.as_mut() {
+            if acc.saw_hunk {
+                match line.as_bytes().first() {
+                    Some(b' ') => {
+                        push_line(&mut acc.old_content, &line[1..]);
+                        push_line(&mut acc.new_content, &line[1..]);
+                    }
+                    Some(b'-') => push_line(&mut acc.old_content, &line[1..]),
+                    Some(b'+') => push_line(&mut acc.new_content, &line[1..]),
+                    Some(b'\\') => {}
+                    None => {
+                        acc.old_content.push('\n');
+                        acc.new_content.push('\n');
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        i += 1;
+    }
+
+    if let Some(acc) = cur.take() {
+        files.push(acc.build());
+    }
+
+    files
+}
+
+fn push_line(buf: &mut String, content: &str) {
+    buf.push_str(content);
+    buf.push('\n');
+}
+
+fn parse_diff_git_header(line: &str) -> Option<(String, String)> {
+    let rest = line.strip_prefix("diff --git ")?;
+    if let Some(idx) = rest.rfind(" b/") {
+        let a = &rest[..idx];
+        let b = &rest[idx + 1..];
+        return Some((strip_ab_prefix(a), strip_ab_prefix(b)));
+    }
+    let parts: Vec<&str> = rest.split_whitespace().collect();
+    if parts.len() >= 2 {
+        return Some((
+            strip_ab_prefix(parts[0]),
+            strip_ab_prefix(parts[parts.len() - 1]),
+        ));
+    }
+    None
+}
+
+fn parse_header_path(raw: &str) -> String {
+    let trimmed = raw.split('\t').next().unwrap_or(raw).trim_end();
+    if trimmed == DEV_NULL {
+        return DEV_NULL.to_string();
+    }
+    strip_ab_prefix(trimmed)
+}
+
+fn strip_ab_prefix(path: &str) -> String {
+    let p = path.trim();
+    p.strip_prefix("a/")
+        .or_else(|| p.strip_prefix("b/"))
+        .unwrap_or(p)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_modified_file() {
+        let diff = "\
+diff --git a/src/main.rs b/src/main.rs
+index 111..222 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,3 +1,3 @@
+ fn main() {
+-    println!(\"old\");
++    println!(\"new\");
+ }
+";
+        let diffs = parse_unified_diff(diff);
+        assert_eq!(diffs.len(), 1);
+        let d = &diffs[0];
+        assert_eq!(d.filename, "src/main.rs");
+        assert_eq!(d.status, FileStatus::Modified);
+        assert_eq!(d.old_content, "fn main() {\n    println!(\"old\");\n}\n");
+        assert_eq!(d.new_content, "fn main() {\n    println!(\"new\");\n}\n");
+    }
+
+    #[test]
+    fn test_parse_added_file() {
+        let diff = "\
+diff --git a/new.txt b/new.txt
+new file mode 100644
+index 000..222
+--- /dev/null
++++ b/new.txt
+@@ -0,0 +1,2 @@
++line one
++line two
+";
+        let diffs = parse_unified_diff(diff);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].filename, "new.txt");
+        assert_eq!(diffs[0].status, FileStatus::Added);
+        assert!(diffs[0].old_content.is_empty());
+        assert_eq!(diffs[0].new_content, "line one\nline two\n");
+    }
+
+    #[test]
+    fn test_parse_deleted_file() {
+        let diff = "\
+diff --git a/gone.txt b/gone.txt
+deleted file mode 100644
+--- a/gone.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-bye one
+-bye two
+";
+        let diffs = parse_unified_diff(diff);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].filename, "gone.txt");
+        assert_eq!(diffs[0].status, FileStatus::Deleted);
+        assert_eq!(diffs[0].old_content, "bye one\nbye two\n");
+        assert!(diffs[0].new_content.is_empty());
+    }
+
+    #[test]
+    fn test_parse_multiple_files() {
+        let diff = "\
+diff --git a/a.txt b/a.txt
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-a old
++a new
+diff --git a/b.txt b/b.txt
+--- a/b.txt
++++ b/b.txt
+@@ -1 +1 @@
+-b old
++b new
+";
+        let diffs = parse_unified_diff(diff);
+        assert_eq!(diffs.len(), 2);
+        assert_eq!(diffs[0].filename, "a.txt");
+        assert_eq!(diffs[1].filename, "b.txt");
+        assert_eq!(diffs[1].new_content, "b new\n");
+    }
+
+    #[test]
+    fn test_parse_plain_unified_diff_no_git_header() {
+        let diff = "\
+--- old.txt\t2020-01-01
++++ new.txt\t2020-01-02
+@@ -1,2 +1,2 @@
+ keep
+-remove
++add
+";
+        let diffs = parse_unified_diff(diff);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].filename, "new.txt");
+        assert_eq!(diffs[0].old_content, "keep\nremove\n");
+        assert_eq!(diffs[0].new_content, "keep\nadd\n");
+    }
+
+    #[test]
+    fn test_parse_multiple_hunks() {
+        let diff = "\
+diff --git a/f.txt b/f.txt
+--- a/f.txt
++++ b/f.txt
+@@ -1,2 +1,2 @@
+ first
+-second
++SECOND
+@@ -10,2 +10,2 @@
+ tenth
+-eleventh
++ELEVENTH
+";
+        let diffs = parse_unified_diff(diff);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].old_content, "first\nsecond\ntenth\neleventh\n");
+        assert_eq!(diffs[0].new_content, "first\nSECOND\ntenth\nELEVENTH\n");
+    }
+
+    #[test]
+    fn test_parse_binary_file() {
+        let diff = "\
+diff --git a/img.png b/img.png
+index 111..222 100644
+Binary files a/img.png and b/img.png differ
+";
+        let diffs = parse_unified_diff(diff);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].filename, "img.png");
+        assert!(diffs[0].is_binary);
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        assert!(parse_unified_diff("").is_empty());
+        assert!(parse_unified_diff("not a diff at all\njust text\n").is_empty());
+    }
+
+    #[test]
+    fn test_load_files_diffs_three_files_errors() {
+        let paths = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert!(load_files_diffs(&paths).is_err());
+    }
+}

--- a/src/command/diff/git.rs
+++ b/src/command/diff/git.rs
@@ -537,6 +537,8 @@ mod tests {
             focus: None,
             origin: None,
             wrap: false,
+            stdin: false,
+            files: None,
         };
 
         let diffs = load_file_diffs(&options, &backend);
@@ -609,6 +611,8 @@ mod tests {
             focus: None,
             origin: None,
             wrap: false,
+            stdin: false,
+            files: None,
         };
 
         let diffs = load_file_diffs(&options, &backend);

--- a/src/command/diff/mod.rs
+++ b/src/command/diff/mod.rs
@@ -3,6 +3,7 @@ mod app;
 mod context;
 mod coordinates;
 mod diff_algo;
+pub mod external;
 pub mod git;
 mod global_search;
 pub mod highlight;
@@ -36,6 +37,8 @@ pub struct DiffOptions {
     pub focus: Option<String>,
     pub origin: Option<String>,
     pub wrap: bool,
+    pub stdin: bool,
+    pub files: Option<Vec<String>>,
 }
 
 #[derive(Clone)]
@@ -338,7 +341,29 @@ fn detect_current_branch_pr() -> Result<String, String> {
     Ok(number)
 }
 
+pub fn is_external_source(options: &DiffOptions) -> bool {
+    options.stdin
+        || options.files.is_some()
+        || matches!(&options.reference, Some(CommitReference::Single(s)) if s == "-")
+}
+
 pub fn run_diff_ui(mut options: DiffOptions, backend: &dyn VcsBackend) -> io::Result<()> {
+    if is_external_source(&options) {
+        let file_diffs = if let Some(paths) = options.files.clone() {
+            external::load_files_diffs(&paths)
+        } else {
+            external::load_stdin_diffs()
+        };
+
+        match file_diffs {
+            Ok(diffs) => return app::run_app_external(options, diffs, backend),
+            Err(e) => {
+                eprintln!("\x1b[91merror:\x1b[0m {}", e);
+                process::exit(1);
+            }
+        }
+    }
+
     // Resolve --detect-pr into options.pr
     if options.detect_pr && options.pr.is_none() {
         let mut spinner = Spinner::new(

--- a/src/command/diff/mod.rs
+++ b/src/command/diff/mod.rs
@@ -477,3 +477,55 @@ pub fn run_diff_ui(mut options: DiffOptions, backend: &dyn VcsBackend) -> io::Re
 
     app::run_app(options, None, backend)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> DiffOptions {
+        DiffOptions {
+            reference: None,
+            pr: None,
+            detect_pr: false,
+            file: None,
+            watch: false,
+            theme: None,
+            stacked: false,
+            focus: None,
+            origin: None,
+            wrap: false,
+            stdin: false,
+            files: None,
+        }
+    }
+
+    #[test]
+    fn test_is_external_source_stdin_flag() {
+        let mut o = opts();
+        o.stdin = true;
+        assert!(is_external_source(&o));
+    }
+
+    #[test]
+    fn test_is_external_source_files() {
+        let mut o = opts();
+        o.files = Some(vec!["a".into(), "b".into()]);
+        assert!(is_external_source(&o));
+    }
+
+    #[test]
+    fn test_is_external_source_dash_reference() {
+        let mut o = opts();
+        o.reference = Some(CommitReference::Single("-".into()));
+        assert!(is_external_source(&o));
+    }
+
+    #[test]
+    fn test_is_external_source_negative() {
+        assert!(!is_external_source(&opts()));
+
+        let mut o = opts();
+        o.reference = Some(CommitReference::Single("HEAD".into()));
+        assert!(!is_external_source(&o));
+    }
+}

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -147,6 +147,14 @@ pub enum Commands {
         /// Soft-wrap long diff lines instead of scrolling horizontally
         #[arg(long)]
         wrap: bool,
+
+        /// Read a unified diff from stdin instead of a repository
+        #[arg(long)]
+        stdin: bool,
+
+        /// Compare two arbitrary files directly, without a repository
+        #[arg(long, num_args = 1.., value_name = "PATH")]
+        files: Option<Vec<String>>,
     },
     /// Interactively configure Lumen (provider, API key)
     Configure,
@@ -179,6 +187,29 @@ mod tests {
         let cli = Cli::try_parse_from(["lumen", "diff", "--wrap"]).unwrap();
         match cli.command {
             Commands::Diff { wrap, .. } => assert!(wrap),
+            _ => panic!("expected diff command"),
+        }
+    }
+
+    #[test]
+    fn test_diff_stdin_flag_parses() {
+        let cli = Cli::try_parse_from(["lumen", "diff", "--stdin"]).unwrap();
+        match cli.command {
+            Commands::Diff { stdin, .. } => assert!(stdin),
+            _ => panic!("expected diff command"),
+        }
+    }
+
+    #[test]
+    fn test_diff_files_flag_parses() {
+        let cli = Cli::try_parse_from(["lumen", "diff", "--files", "old.txt", "new.txt"]).unwrap();
+        match cli.command {
+            Commands::Diff { files, .. } => {
+                assert_eq!(
+                    files,
+                    Some(vec!["old.txt".to_string(), "new.txt".to_string()])
+                );
+            }
             _ => panic!("expected diff command"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,3 +197,67 @@ fn read_from_stdin() -> Result<String, LumenError> {
     eprintln!("Reading commit SHA from stdin: '{}'", buffer.trim());
     Ok(buffer)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn diff_cmd(stdin: bool, files: Option<Vec<String>>, reference: Option<&str>) -> Commands {
+        Commands::Diff {
+            reference: reference.map(|s| CommitReference::Single(s.to_string())),
+            pr: None,
+            detect_pr: false,
+            file: None,
+            watch: false,
+            theme: None,
+            stacked: false,
+            focus: None,
+            origin: None,
+            wrap: false,
+            stdin,
+            files,
+        }
+    }
+
+    #[test]
+    fn test_external_label_stdin() {
+        assert_eq!(
+            external_diff_label(&diff_cmd(true, None, None)),
+            Some(Some("stdin".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_external_label_dash_reference() {
+        assert_eq!(
+            external_diff_label(&diff_cmd(false, None, Some("-"))),
+            Some(Some("stdin".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_external_label_two_files() {
+        let files = Some(vec!["old".to_string(), "new".to_string()]);
+        assert_eq!(
+            external_diff_label(&diff_cmd(false, files, None)),
+            Some(Some("old → new".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_external_label_three_files_has_no_label_but_is_external() {
+        let files = Some(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+        assert_eq!(external_diff_label(&diff_cmd(false, files, None)), Some(None));
+    }
+
+    #[test]
+    fn test_external_label_none_for_regular_diff() {
+        assert_eq!(external_diff_label(&diff_cmd(false, None, Some("HEAD"))), None);
+        assert_eq!(external_diff_label(&diff_cmd(false, None, None)), None);
+    }
+
+    #[test]
+    fn test_external_label_none_for_non_diff_command() {
+        assert_eq!(external_diff_label(&Commands::List), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use error::LumenError;
 use git_entity::{commit::Commit, diff::Diff, GitEntity};
 use std::io::Read;
 use std::process;
-use vcs::VcsBackendType;
+use vcs::{NoopBackend, VcsBackend, VcsBackendType};
 
 mod ai_prompt;
 mod command;
@@ -37,10 +37,12 @@ async fn run() -> Result<(), LumenError> {
     let provider = provider::LumenProvider::new(config.provider, config.api_key, config.model)?;
     let command = command::LumenCommand::new(provider);
 
-    // Get VCS backend based on CLI override or auto-detection
     let cwd = std::env::current_dir()?;
     let vcs_override = cli.vcs.map(VcsBackendType::from);
-    let backend = vcs::get_backend(&cwd, vcs_override)?;
+    let backend: Box<dyn VcsBackend> = match external_diff_label(&cli.command) {
+        Some(label) => Box::new(NoopBackend::new(label)),
+        None => vcs::get_backend(&cwd, vcs_override)?,
+    };
 
     match cli.command {
         Commands::Explain {
@@ -133,6 +135,8 @@ async fn run() -> Result<(), LumenError> {
             focus,
             origin,
             wrap,
+            stdin,
+            files,
         } => {
             let options = command::diff::DiffOptions {
                 reference,
@@ -145,6 +149,8 @@ async fn run() -> Result<(), LumenError> {
                 focus,
                 origin,
                 wrap: wrap || config.wrap.unwrap_or(false),
+                stdin,
+                files,
             };
             command::diff::run_diff_ui(options, backend.as_ref())?;
         }
@@ -154,6 +160,34 @@ async fn run() -> Result<(), LumenError> {
     }
 
     Ok(())
+}
+
+fn external_diff_label(command: &Commands) -> Option<Option<String>> {
+    let Commands::Diff {
+        reference,
+        stdin,
+        files,
+        ..
+    } = command
+    else {
+        return None;
+    };
+
+    if let Some(paths) = files {
+        let label = if paths.len() == 2 {
+            Some(format!("{} → {}", paths[0], paths[1]))
+        } else {
+            None
+        };
+        return Some(label);
+    }
+
+    let from_stdin = *stdin || matches!(reference, Some(CommitReference::Single(s)) if s == "-");
+    if from_stdin {
+        return Some(Some("stdin".to_string()));
+    }
+
+    None
 }
 
 fn read_from_stdin() -> Result<String, LumenError> {

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -7,6 +7,7 @@ mod detection;
 mod git;
 #[cfg(feature = "jj")]
 mod jj;
+mod noop;
 #[cfg(test)]
 pub mod test_utils;
 
@@ -15,6 +16,7 @@ pub use detection::{detect_vcs_type, VcsType};
 pub use git::GitBackend;
 #[cfg(feature = "jj")]
 pub use jj::JjBackend;
+pub use noop::NoopBackend;
 
 use std::path::Path;
 

--- a/src/vcs/noop.rs
+++ b/src/vcs/noop.rs
@@ -1,0 +1,79 @@
+use std::path::Path;
+
+use super::backend::{CommitInfo, StackedCommitInfo, VcsBackend, VcsError};
+
+pub struct NoopBackend {
+    label: Option<String>,
+}
+
+impl NoopBackend {
+    pub fn new(label: Option<String>) -> Self {
+        Self { label }
+    }
+}
+
+impl VcsBackend for NoopBackend {
+    fn get_commit(&self, _reference: &str) -> Result<CommitInfo, VcsError> {
+        Err(VcsError::NotARepository)
+    }
+
+    fn get_working_tree_diff(&self, _staged: bool) -> Result<String, VcsError> {
+        Err(VcsError::NotARepository)
+    }
+
+    fn get_range_diff(&self, _from: &str, _to: &str, _three_dot: bool) -> Result<String, VcsError> {
+        Err(VcsError::NotARepository)
+    }
+
+    fn get_changed_files(&self, _reference: &str) -> Result<Vec<String>, VcsError> {
+        Ok(Vec::new())
+    }
+
+    fn get_file_content_at_ref(&self, _reference: &str, _path: &Path) -> Result<String, VcsError> {
+        Ok(String::new())
+    }
+
+    fn get_current_branch(&self) -> Result<Option<String>, VcsError> {
+        Ok(self.label.clone())
+    }
+
+    fn get_commit_log_for_fzf(&self) -> Result<String, VcsError> {
+        Err(VcsError::NotARepository)
+    }
+
+    fn resolve_ref(&self, _reference: &str) -> Result<String, VcsError> {
+        Err(VcsError::NotARepository)
+    }
+
+    fn get_working_tree_changed_files(&self) -> Result<Vec<String>, VcsError> {
+        Ok(Vec::new())
+    }
+
+    fn get_merge_base(&self, _ref1: &str, _ref2: &str) -> Result<String, VcsError> {
+        Err(VcsError::NotARepository)
+    }
+
+    fn working_copy_parent_ref(&self) -> &'static str {
+        ""
+    }
+
+    fn get_range_changed_files(&self, _from: &str, _to: &str) -> Result<Vec<String>, VcsError> {
+        Ok(Vec::new())
+    }
+
+    fn get_parent_ref_or_empty(&self, _reference: &str) -> Result<String, VcsError> {
+        Ok(String::new())
+    }
+
+    fn get_commits_in_range(
+        &self,
+        _from: &str,
+        _to: &str,
+    ) -> Result<Vec<StackedCommitInfo>, VcsError> {
+        Ok(Vec::new())
+    }
+
+    fn name(&self) -> &'static str {
+        "diff"
+    }
+}

--- a/src/vcs/noop.rs
+++ b/src/vcs/noop.rs
@@ -77,3 +77,24 @@ impl VcsBackend for NoopBackend {
         "diff"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_label_surfaced_as_branch() {
+        let b = NoopBackend::new(Some("stdin".to_string()));
+        assert_eq!(b.get_current_branch().unwrap(), Some("stdin".to_string()));
+        assert_eq!(b.name(), "diff");
+    }
+
+    #[test]
+    fn test_no_label_and_empty_collections() {
+        let b = NoopBackend::new(None);
+        assert_eq!(b.get_current_branch().unwrap(), None);
+        assert!(b.get_changed_files("x").unwrap().is_empty());
+        assert!(b.get_working_tree_changed_files().unwrap().is_empty());
+        assert!(b.get_commit("x").is_err());
+    }
+}


### PR DESCRIPTION
Closes #140.

Makes `lumen diff` render diffs without a repository:

```bash
arc diff | lumen diff --stdin      # or: lumen diff -
lumen diff --files old.txt new.txt
```

The unified diff is parsed into the existing `FileDiff` pipeline, so highlighting, sidebar, search and annotations work as usual.

Notes:
- `--stdin` shows the hunks and their context (a patch), not the whole file.
- Three-way (diff3) mode is not included.
- When a diff is piped in, stdin is reconnected to the terminal so the viewer can still read input (via stdout/stderr, since macOS `/dev/tty` cannot be registered by crossterm's kqueue reader).
