### PR TITLE
feat(explain): add --grouped diff summary mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ lumen explain main..feature/A
 # Ask specific questions
 lumen explain --query "What's the performance impact of these changes?"
 
+# Group changes into logical clusters with a summary per group
+lumen explain --grouped
+
 # Interactive commit selection (requires: fzf)
 lumen explain --list
 ```

--- a/src/ai_prompt.rs
+++ b/src/ai_prompt.rs
@@ -96,6 +96,64 @@ impl AIPrompt {
         })
     }
 
+    pub fn build_grouped_explain_prompt(command: &ExplainCommand) -> Result<Self, AIPromptError> {
+        let system_prompt = String::from(indoc! {r#"
+            You are a code-review assistant that clusters a Git diff into logical groups
+            based on purpose (feature, refactor, tests, config, docs, chore, etc.).
+            Prefer more, smaller, focused groups over fewer large ones — split unrelated
+            changes into separate groups even within the same purpose.
+            Test files must be grouped together with the implementation they test, not
+            split out into a separate "tests" group.
+            Respond with ONLY a single valid JSON object. Do not use markdown code fences.
+            Do not include any prose before or after the JSON object.
+        "#});
+
+        let diff_block = match &command.git_entity {
+            GitEntity::Commit(commit) => {
+                formatdoc! {"
+                    Context - Commit:
+
+                    Message: {msg}
+                    Changes:
+                    ```diff
+                    {diff}
+                    ```
+                    ",
+                    msg = commit.message,
+                    diff = commit.diff
+                }
+            }
+            GitEntity::Diff(Diff::WorkingTree { diff, .. } | Diff::CommitsRange { diff, .. }) => {
+                formatdoc! {"
+                    Context - Changes:
+
+                    ```diff
+                    {diff}
+                    ```
+                    "
+                }
+            }
+        };
+
+        let user_prompt = formatdoc! {r#"
+            {diff_block}
+
+            Group the changes above into logical clusters and respond with ONLY a JSON object
+            matching this exact shape:
+            {{"groups":[{{"title":"string","files":["path/to/file",...],"summary":"1-3 sentence prose summary"}}],"overall_summary":"2-4 sentence prose summary, omit or use empty string if the diff is a single logical change"}}
+
+            `files` must be exact repo-relative paths copied verbatim from the diff's file headers.
+            Every changed file must appear in exactly one group. If the diff represents a single
+            logical change, return exactly one group.
+            "#
+        };
+
+        Ok(AIPrompt {
+            system_prompt,
+            user_prompt,
+        })
+    }
+
     pub fn build_draft_prompt(command: &DraftCommand) -> Result<Self, AIPromptError> {
         let GitEntity::Diff(Diff::WorkingTree { diff, .. }) = &command.git_entity else {
             return Err(AIPromptError(
@@ -167,5 +225,60 @@ impl AIPrompt {
             system_prompt,
             user_prompt,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn working_tree_command(diff: &str, grouped: bool) -> ExplainCommand {
+        ExplainCommand {
+            git_entity: GitEntity::Diff(Diff::WorkingTree {
+                staged: false,
+                diff: diff.to_string(),
+            }),
+            query: None,
+            grouped,
+        }
+    }
+
+    #[test]
+    fn build_explain_prompt_produces_plain_prompt_shape() {
+        let command = working_tree_command("diff --git a/src/a.rs b/src/a.rs", false);
+
+        let prompt = AIPrompt::build_explain_prompt(&command).unwrap();
+
+        assert!(prompt
+            .user_prompt
+            .contains("diff --git a/src/a.rs b/src/a.rs"));
+        assert!(prompt.user_prompt.contains("Key changes"));
+    }
+
+    #[test]
+    fn build_grouped_explain_prompt_embeds_diff_and_json_contract() {
+        let diff = "diff --git a/src/a.rs b/src/a.rs\n+++ b/src/a.rs";
+        let command = working_tree_command(diff, true);
+
+        let prompt = AIPrompt::build_grouped_explain_prompt(&command).unwrap();
+
+        assert!(prompt.user_prompt.contains(diff));
+        assert!(prompt.user_prompt.contains("JSON"));
+        assert!(prompt.user_prompt.contains("groups"));
+        assert!(prompt.user_prompt.contains("overall_summary"));
+    }
+
+    #[test]
+    fn build_grouped_explain_prompt_instructs_smaller_groups_and_colocated_tests() {
+        let command = working_tree_command("diff --git a/src/a.rs b/src/a.rs", true);
+
+        let prompt = AIPrompt::build_grouped_explain_prompt(&command).unwrap();
+
+        assert!(prompt
+            .system_prompt
+            .contains("more, smaller, focused groups"));
+        assert!(prompt
+            .system_prompt
+            .contains("Test files must be grouped together with the implementation they test"));
     }
 }

--- a/src/command/explain.rs
+++ b/src/command/explain.rs
@@ -1,31 +1,70 @@
 use spinoff::{spinners, Color, Spinner};
 
-use crate::{error::LumenError, git_entity::GitEntity, provider::LumenProvider};
+use crate::{
+    error::LumenError,
+    git_entity::{diff::Diff, GitEntity},
+    provider::LumenProvider,
+};
 
 use super::LumenCommand;
 
 pub struct ExplainCommand {
     pub git_entity: GitEntity,
     pub query: Option<String>,
+    pub grouped: bool,
+}
+
+/// Extract the raw diff text out of a [`GitEntity`], regardless of variant.
+fn diff_text(git_entity: &GitEntity) -> &str {
+    match git_entity {
+        GitEntity::Commit(commit) => &commit.diff,
+        GitEntity::Diff(Diff::WorkingTree { diff, .. } | Diff::CommitsRange { diff, .. }) => diff,
+    }
 }
 
 impl ExplainCommand {
+    fn diff_text(&self) -> &str {
+        diff_text(&self.git_entity)
+    }
+
     pub async fn execute(&self, provider: &LumenProvider) -> Result<(), LumenError> {
         LumenCommand::print_with_mdcat(self.git_entity.format_static_details(provider))?;
         if let Some(query) = &self.query {
             LumenCommand::print_with_mdcat(format!("`query`: {query}"))?;
         }
 
-        let spinner_text = match &self.query {
-            Some(_) => "Generating answer...".to_string(),
-            None => "Generating summary...".to_string(),
+        let spinner_text = if self.grouped {
+            "Grouping changes...".to_string()
+        } else {
+            match &self.query {
+                Some(_) => "Generating answer...".to_string(),
+                None => "Generating summary...".to_string(),
+            }
         };
 
         let mut spinner = Spinner::new(spinners::Dots, spinner_text, Color::Blue);
-        let result = provider.explain(self).await?;
+        let result = if self.grouped {
+            provider.explain_grouped(self).await?
+        } else {
+            provider.explain(self).await?
+        };
         spinner.success("Done");
 
-        LumenCommand::print_with_mdcat(result)?;
+        if self.grouped {
+            let mut summary = crate::grouped_summary::parse_grouped_summary(&result)?;
+            let ground_truth = crate::grouped_summary::files_from_unified_diff(self.diff_text());
+            let report = crate::grouped_summary::reconcile_groups(&mut summary, &ground_truth);
+            if !report.is_clean() {
+                eprintln!(
+                    "note: grouping adjusted ({} unknown, {} ungrouped file(s))",
+                    report.unknown_files.len(),
+                    report.ungrouped_files.len()
+                );
+            }
+            LumenCommand::print_with_mdcat(crate::grouped_summary::render_markdown(&summary))?;
+        } else {
+            LumenCommand::print_with_mdcat(result)?;
+        }
         Ok(())
     }
 }

--- a/src/command/list.rs
+++ b/src/command/list.rs
@@ -21,6 +21,7 @@ impl ListCommand {
         ExplainCommand {
             git_entity,
             query: None,
+            grouped: false,
         }
         .execute(provider)
         .await

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -21,6 +21,7 @@ pub enum CommandType<'a> {
     Explain {
         git_entity: GitEntity,
         query: Option<String>,
+        grouped: bool,
     },
     List {
         backend: &'a dyn VcsBackend,
@@ -46,10 +47,18 @@ impl LumenCommand {
 
     pub async fn execute(&self, command_type: CommandType<'_>) -> Result<(), LumenError> {
         match command_type {
-            CommandType::Explain { git_entity, query } => {
-                ExplainCommand { git_entity, query }
-                    .execute(&self.provider)
-                    .await
+            CommandType::Explain {
+                git_entity,
+                query,
+                grouped,
+            } => {
+                ExplainCommand {
+                    git_entity,
+                    query,
+                    grouped,
+                }
+                .execute(&self.provider)
+                .await
             }
             CommandType::List { backend } => ListCommand.execute(&self.provider, backend).await,
             CommandType::Draft {

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -91,6 +91,10 @@ pub enum Commands {
         /// Select commit interactively using fuzzy finder
         #[arg(long)]
         list: bool,
+
+        /// Group the changes into logical clusters with a summary per group
+        #[arg(long, conflicts_with = "query")]
+        grouped: bool,
     },
     /// List all commits in an interactive fuzzy-finder, and summarize the changes
     List,
@@ -180,6 +184,49 @@ mod tests {
         match cli.command {
             Commands::Diff { wrap, .. } => assert!(wrap),
             _ => panic!("expected diff command"),
+        }
+    }
+
+    #[test]
+    fn test_explain_grouped_flag_parses() {
+        let cli = Cli::try_parse_from(["lumen", "explain", "--grouped"]).unwrap();
+        match cli.command {
+            Commands::Explain { grouped, .. } => assert!(grouped),
+            _ => panic!("expected explain command"),
+        }
+    }
+
+    #[test]
+    fn test_explain_grouped_conflicts_with_query() {
+        let result = Cli::try_parse_from(["lumen", "explain", "--grouped", "--query", "x"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_explain_grouped_composes_with_staged() {
+        let cli = Cli::try_parse_from(["lumen", "explain", "--grouped", "--staged"]).unwrap();
+        match cli.command {
+            Commands::Explain {
+                grouped, staged, ..
+            } => {
+                assert!(grouped);
+                assert!(staged);
+            }
+            _ => panic!("expected explain command"),
+        }
+    }
+
+    #[test]
+    fn test_explain_grouped_composes_with_reference() {
+        let cli = Cli::try_parse_from(["lumen", "explain", "--grouped", "HEAD"]).unwrap();
+        match cli.command {
+            Commands::Explain {
+                grouped, reference, ..
+            } => {
+                assert!(grouped);
+                assert!(reference.is_some());
+            }
+            _ => panic!("expected explain command"),
         }
     }
 }

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -35,7 +35,7 @@ pub const ALL_PROVIDERS: &[ProviderInfo] = &[
         id: "claude",
         provider_type: ProviderType::Claude,
         display_name: "Claude (Anthropic)",
-        default_model: "claude-sonnet-4-5-20250930",
+        default_model: "claude-sonnet-4-5-20250929",
         env_key: "ANTHROPIC_API_KEY",
     },
     ProviderInfo {
@@ -98,3 +98,17 @@ impl ProviderInfo {
             .expect("All provider types must be defined in ALL_PROVIDERS")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_default_model_is_available() {
+        assert_eq!(
+            ProviderInfo::for_provider(ProviderType::Claude).default_model,
+            "claude-sonnet-4-5-20250929"
+        );
+    }
+}
+

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
-use crate::{git_entity::diff::DiffError, provider::ProviderError, vcs::VcsError};
+use crate::{
+    git_entity::diff::DiffError, grouped_summary::GroupedSummaryError, provider::ProviderError,
+    vcs::VcsError,
+};
 use std::io;
 use thiserror::Error;
 
@@ -34,4 +37,7 @@ pub enum LumenError {
 
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    GroupedSummaryError(#[from] GroupedSummaryError),
 }

--- a/src/grouped_summary.rs
+++ b/src/grouped_summary.rs
@@ -1,0 +1,395 @@
+use std::collections::HashSet;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GroupedSummary {
+    pub groups: Vec<DiffGroup>,
+    #[serde(default)]
+    pub overall_summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DiffGroup {
+    pub title: String,
+    #[serde(default)]
+    pub files: Vec<String>,
+    pub summary: String,
+}
+
+#[derive(Error, Debug)]
+pub enum GroupedSummaryError {
+    #[error("could not parse grouped summary as JSON: {0}")]
+    Parse(#[from] serde_json::Error),
+    #[error("model returned an empty grouped summary")]
+    Empty,
+}
+
+#[derive(Debug, Default)]
+pub struct ReconcileReport {
+    /// Referenced by a group but not in ground truth.
+    pub unknown_files: Vec<String>,
+    /// In ground truth but appear in no group.
+    pub ungrouped_files: Vec<String>,
+}
+
+impl ReconcileReport {
+    pub fn is_clean(&self) -> bool {
+        self.unknown_files.is_empty() && self.ungrouped_files.is_empty()
+    }
+}
+
+/// Strip a markdown code fence around a JSON payload, with a fallback that
+/// slices out the outermost `{...}` if stray prose surrounds the JSON.
+fn strip_json_fence(raw: &str) -> &str {
+    let trimmed = raw.trim();
+
+    let unfenced = if trimmed.starts_with("```") {
+        let without_leading_fence = trimmed
+            .strip_prefix("```")
+            .and_then(|rest| rest.split_once('\n'))
+            .map(|(_, rest)| rest)
+            .unwrap_or(trimmed);
+
+        without_leading_fence
+            .trim_end()
+            .strip_suffix("```")
+            .unwrap_or(without_leading_fence)
+            .trim()
+    } else {
+        trimmed
+    };
+
+    if unfenced.starts_with('{') {
+        return unfenced;
+    }
+
+    match (unfenced.find('{'), unfenced.rfind('}')) {
+        (Some(start), Some(end)) if start <= end => &unfenced[start..=end],
+        _ => trimmed,
+    }
+}
+
+/// Parse a model response into a [`GroupedSummary`], tolerating markdown
+/// fences and stray prose around the JSON payload.
+pub fn parse_grouped_summary(raw: &str) -> Result<GroupedSummary, GroupedSummaryError> {
+    let json = strip_json_fence(raw);
+    let summary: GroupedSummary = serde_json::from_str(json)?;
+
+    if summary.groups.is_empty() {
+        return Err(GroupedSummaryError::Empty);
+    }
+
+    Ok(summary)
+}
+
+/// Extract the ordered, deduplicated list of file paths changed in a unified
+/// diff, straight from its `+++`/`---` file headers.
+pub fn files_from_unified_diff(diff: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut files = Vec::new();
+
+    let lines: Vec<&str> = diff.lines().collect();
+    for (idx, line) in lines.iter().enumerate() {
+        let path = if let Some(new_path) = line.strip_prefix("+++ b/") {
+            Some(new_path.to_string())
+        } else if *line == "+++ /dev/null" {
+            lines
+                .get(idx.wrapping_sub(1))
+                .and_then(|prev| prev.strip_prefix("--- a/"))
+                .map(str::to_string)
+        } else {
+            None
+        };
+
+        if let Some(path) = path {
+            if seen.insert(path.clone()) {
+                files.push(path);
+            }
+        }
+    }
+
+    files
+}
+
+/// Cross-check the model's grouping against the diff's ground-truth file
+/// list, dropping hallucinated files and collecting anything left out into
+/// an `Ungrouped` catch-all group.
+pub fn reconcile_groups(summary: &mut GroupedSummary, ground_truth: &[String]) -> ReconcileReport {
+    let known: HashSet<&str> = ground_truth.iter().map(String::as_str).collect();
+    let mut report = ReconcileReport::default();
+    let mut seen_unknown = HashSet::new();
+    let mut grouped_files: HashSet<String> = HashSet::new();
+
+    for group in &mut summary.groups {
+        let mut kept = Vec::with_capacity(group.files.len());
+        for file in group.files.drain(..) {
+            if known.contains(file.as_str()) {
+                grouped_files.insert(file.clone());
+                kept.push(file);
+            } else if seen_unknown.insert(file.clone()) {
+                report.unknown_files.push(file);
+            }
+        }
+        group.files = kept;
+    }
+
+    let ungrouped: Vec<String> = ground_truth
+        .iter()
+        .filter(|file| !grouped_files.contains(file.as_str()))
+        .cloned()
+        .collect();
+
+    if !ungrouped.is_empty() {
+        report.ungrouped_files = ungrouped.clone();
+        summary.groups.push(DiffGroup {
+            title: "Ungrouped".to_string(),
+            files: ungrouped,
+            summary: "Files not confidently assigned to a group.".to_string(),
+        });
+    }
+
+    report
+}
+
+/// Render a [`GroupedSummary`] as markdown for terminal display.
+pub fn render_markdown(summary: &GroupedSummary) -> String {
+    let mut out = String::new();
+
+    for group in &summary.groups {
+        out.push_str(&format!("## {}\n\n", group.title));
+        for file in &group.files {
+            out.push_str(&format!("- `{}`\n", file));
+        }
+        out.push('\n');
+        out.push_str(&group.summary);
+        out.push_str("\n\n");
+    }
+
+    if let Some(overall) = &summary.overall_summary {
+        if !overall.is_empty() {
+            out.push_str("## Overall Summary\n\n");
+            out.push_str(overall);
+            out.push('\n');
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_json_fence_passes_through_plain_json() {
+        let raw = r#"{"groups":[]}"#;
+        assert_eq!(strip_json_fence(raw), r#"{"groups":[]}"#);
+    }
+
+    #[test]
+    fn strip_json_fence_strips_json_language_tag() {
+        let raw = "```json\n{\"groups\":[]}\n```";
+        assert_eq!(strip_json_fence(raw), "{\"groups\":[]}");
+    }
+
+    #[test]
+    fn strip_json_fence_strips_bare_fence() {
+        let raw = "```\n{\"groups\":[]}\n```";
+        assert_eq!(strip_json_fence(raw), "{\"groups\":[]}");
+    }
+
+    #[test]
+    fn strip_json_fence_extracts_json_from_stray_prose() {
+        let raw = "Here you go:\n{\"groups\":[]}\nHope that helps!";
+        assert_eq!(strip_json_fence(raw), "{\"groups\":[]}");
+    }
+
+    #[test]
+    fn parse_grouped_summary_parses_groups_and_overall_summary() {
+        let raw = r#"{"groups":[{"title":"Feature","files":["src/a.rs"],"summary":"Adds a."}],"overall_summary":"Adds feature a."}"#;
+        let summary = parse_grouped_summary(raw).unwrap();
+        assert_eq!(summary.groups.len(), 1);
+        assert_eq!(summary.groups[0].title, "Feature");
+        assert_eq!(summary.overall_summary, Some("Adds feature a.".to_string()));
+    }
+
+    #[test]
+    fn parse_grouped_summary_defaults_overall_summary_to_none() {
+        let raw = r#"{"groups":[{"title":"Feature","files":["src/a.rs"],"summary":"Adds a."}]}"#;
+        let summary = parse_grouped_summary(raw).unwrap();
+        assert_eq!(summary.overall_summary, None);
+    }
+
+    #[test]
+    fn parse_grouped_summary_rejects_empty_groups() {
+        let raw = r#"{"groups":[]}"#;
+        assert!(matches!(
+            parse_grouped_summary(raw),
+            Err(GroupedSummaryError::Empty)
+        ));
+    }
+
+    #[test]
+    fn parse_grouped_summary_rejects_garbage() {
+        let raw = "not json at all";
+        assert!(matches!(
+            parse_grouped_summary(raw),
+            Err(GroupedSummaryError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn files_from_unified_diff_returns_ordered_deduped_paths() {
+        let diff = indoc::indoc! {"
+            diff --git a/src/a.rs b/src/a.rs
+            index 1111111..2222222 100644
+            --- a/src/a.rs
+            +++ b/src/a.rs
+            @@ -1,1 +1,1 @@
+            -old
+            +new
+            diff --git a/src/b.rs b/src/b.rs
+            index 3333333..4444444 100644
+            --- a/src/b.rs
+            +++ b/src/b.rs
+            @@ -1,1 +1,1 @@
+            -old
+            +new
+        "};
+
+        assert_eq!(
+            files_from_unified_diff(diff),
+            vec!["src/a.rs".to_string(), "src/b.rs".to_string()]
+        );
+    }
+
+    #[test]
+    fn files_from_unified_diff_falls_back_to_old_path_for_deletions() {
+        let diff = indoc::indoc! {"
+            diff --git a/src/deleted.rs b/src/deleted.rs
+            deleted file mode 100644
+            index 1111111..0000000
+            --- a/src/deleted.rs
+            +++ /dev/null
+            @@ -1,1 +0,0 @@
+            -gone
+        "};
+
+        assert_eq!(
+            files_from_unified_diff(diff),
+            vec!["src/deleted.rs".to_string()]
+        );
+    }
+
+    #[test]
+    fn reconcile_groups_is_clean_when_all_files_accounted_for() {
+        let mut summary = GroupedSummary {
+            groups: vec![DiffGroup {
+                title: "Feature".to_string(),
+                files: vec!["src/a.rs".to_string()],
+                summary: "Adds a.".to_string(),
+            }],
+            overall_summary: None,
+        };
+        let ground_truth = vec!["src/a.rs".to_string()];
+
+        let report = reconcile_groups(&mut summary, &ground_truth);
+
+        assert!(report.is_clean());
+        assert_eq!(summary.groups.len(), 1);
+    }
+
+    #[test]
+    fn reconcile_groups_drops_unknown_files_and_reports_them() {
+        let mut summary = GroupedSummary {
+            groups: vec![DiffGroup {
+                title: "Feature".to_string(),
+                files: vec!["src/a.rs".to_string(), "src/hallucinated.rs".to_string()],
+                summary: "Adds a.".to_string(),
+            }],
+            overall_summary: None,
+        };
+        let ground_truth = vec!["src/a.rs".to_string()];
+
+        let report = reconcile_groups(&mut summary, &ground_truth);
+
+        assert_eq!(summary.groups[0].files, vec!["src/a.rs".to_string()]);
+        assert_eq!(
+            report.unknown_files,
+            vec!["src/hallucinated.rs".to_string()]
+        );
+        assert!(!report.is_clean());
+    }
+
+    #[test]
+    fn reconcile_groups_appends_ungrouped_group_for_missing_files() {
+        let mut summary = GroupedSummary {
+            groups: vec![DiffGroup {
+                title: "Feature".to_string(),
+                files: vec!["src/a.rs".to_string()],
+                summary: "Adds a.".to_string(),
+            }],
+            overall_summary: None,
+        };
+        let ground_truth = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
+
+        let report = reconcile_groups(&mut summary, &ground_truth);
+
+        assert_eq!(report.ungrouped_files, vec!["src/b.rs".to_string()]);
+        assert!(!report.is_clean());
+        assert_eq!(summary.groups.len(), 2);
+        let ungrouped = &summary.groups[1];
+        assert_eq!(ungrouped.title, "Ungrouped");
+        assert_eq!(ungrouped.files, vec!["src/b.rs".to_string()]);
+    }
+
+    #[test]
+    fn render_markdown_renders_groups_and_overall_summary() {
+        let summary = GroupedSummary {
+            groups: vec![
+                DiffGroup {
+                    title: "Feature".to_string(),
+                    files: vec!["src/a.rs".to_string()],
+                    summary: "Adds a.".to_string(),
+                },
+                DiffGroup {
+                    title: "Tests".to_string(),
+                    files: vec!["tests/a_test.rs".to_string()],
+                    summary: "Covers a.".to_string(),
+                },
+            ],
+            overall_summary: Some("Adds feature a with tests.".to_string()),
+        };
+
+        let expected = "## Feature\n\n\
+            - `src/a.rs`\n\
+            \n\
+            Adds a.\n\n\
+            ## Tests\n\n\
+            - `tests/a_test.rs`\n\
+            \n\
+            Covers a.\n\n\
+            ## Overall Summary\n\n\
+            Adds feature a with tests.\n";
+
+        assert_eq!(render_markdown(&summary), expected);
+    }
+
+    #[test]
+    fn render_markdown_omits_overall_summary_section_when_none() {
+        let summary = GroupedSummary {
+            groups: vec![DiffGroup {
+                title: "Feature".to_string(),
+                files: vec!["src/a.rs".to_string()],
+                summary: "Adds a.".to_string(),
+            }],
+            overall_summary: None,
+        };
+
+        let expected = "## Feature\n\n- `src/a.rs`\n\nAdds a.\n\n";
+
+        assert_eq!(render_markdown(&summary), expected);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod commit_reference;
 mod config;
 mod error;
 mod git_entity;
+mod grouped_summary;
 mod provider;
 mod vcs;
 
@@ -48,6 +49,7 @@ async fn run() -> Result<(), LumenError> {
             staged,
             query,
             list,
+            grouped,
         } => {
             let git_entity = if list {
                 let sha = LumenCommand::get_sha_from_fzf(backend.as_ref())?;
@@ -94,7 +96,11 @@ async fn run() -> Result<(), LumenError> {
             };
 
             command
-                .execute(command::CommandType::Explain { git_entity, query })
+                .execute(command::CommandType::Explain {
+                    git_entity,
+                    query,
+                    grouped,
+                })
                 .await?;
         }
         Commands::List => {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -158,6 +158,11 @@ impl LumenProvider {
         self.complete(prompt).await
     }
 
+    pub async fn explain_grouped(&self, command: &ExplainCommand) -> Result<String, ProviderError> {
+        let prompt = AIPrompt::build_grouped_explain_prompt(command)?;
+        self.complete(prompt).await
+    }
+
     pub async fn draft(&self, command: &DraftCommand) -> Result<String, ProviderError> {
         let prompt = AIPrompt::build_draft_prompt(command)?;
         self.complete(prompt).await


### PR DESCRIPTION
Adds lumen explain --grouped, which clusters a diff into logical groups with a per-group AI summary plus an optional overall summary.