### PR TITLE
feat(diff): add --save-viewed for local viewed-state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ lumen diff --file src/main.rs --file src/lib.rs
 # Watch mode - auto-refresh on file changes
 lumen diff --watch
 
+# Persist viewed-file state locally across sessions (opt-in)
+lumen diff --watch --save-viewed
+
 # Stacked mode - review commits one by one
 lumen diff main..feature --stacked
 
@@ -125,6 +128,8 @@ This displays each commit individually, letting you navigate through them:
 The header shows the current commit position, SHA, and message. Viewed files are tracked per commit, so your progress is preserved when navigating.
 
 When viewing a PR, you can mark files as viewed (syncs with GitHub) using the `space` keybinding.
+
+Outside of PR mode, `--save-viewed` persists viewed-file state locally across sessions instead — it's opt-in, never talks to GitHub, and works the same whether or not the branch has an associated PR. State is keyed by repo + branch + each file's content hash, so it survives quitting `--watch` and rebases (a file only shows as viewed again if its contents match what you last saw). State files live under `$XDG_STATE_HOME/lumen/viewed/` (or `~/.local/state/lumen/viewed/` if unset).
 
 #### Theme Configuration
 

--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::TryRecvError;
 use std::time::Duration;
 
@@ -51,6 +52,7 @@ use super::types::{
     ChangeType, CursorPosition, DiffFullscreen, DiffPanelFocus, FileStatus, FocusedPanel,
     SelectionMode, SidebarItem,
 };
+use super::viewed_state;
 use super::watcher::{setup_watcher, WatchEvent};
 use super::{
     fetch_viewed_files, mark_file_as_viewed_async, unmark_file_as_viewed_async, DiffOptions, PrInfo,
@@ -293,6 +295,82 @@ fn sync_viewed_files_from_github(pr_info: &PrInfo, state: &mut AppState) {
     }
 }
 
+/// Resolve local `--save-viewed` persistence for the current repo+branch and
+/// apply any previously-saved viewed state. No-op if `save_viewed` is false.
+/// Purely local — never touches GitHub/PR state.
+fn init_viewed_state_persistence(
+    state: &mut AppState,
+    save_viewed: bool,
+    backend: &dyn VcsBackend,
+) {
+    if !save_viewed {
+        return;
+    }
+
+    let branch = backend.get_current_branch().ok().flatten();
+    let path = branch
+        .as_deref()
+        .and_then(|b| viewed_state::resolve_path_for_current_repo(Some(b)));
+
+    let Some(path) = path else {
+        eprintln!(
+            "lumen: --save-viewed has no effect in detached HEAD (no branch to key state on)"
+        );
+        return;
+    };
+
+    if let Some(repo_viewed_dir) = path.parent() {
+        if let Some(branches) = viewed_state::list_local_branches() {
+            viewed_state::prune_stale_branches(repo_viewed_dir, &branches);
+        }
+    }
+
+    state.viewed_state_path = Some(path);
+    apply_saved_viewed_state(state);
+}
+
+/// Mark files as viewed whose current working-tree content hash matches a
+/// hash previously saved to `state.viewed_state_path`. Additive: never
+/// clears existing marks, since another process may have saved entries
+/// this session hasn't seen yet.
+fn apply_saved_viewed_state(state: &mut AppState) {
+    let Some(path) = state.viewed_state_path.clone() else {
+        return;
+    };
+    let saved = viewed_state::load(&path);
+    for idx in 0..state.file_diffs.len() {
+        let filename = &state.file_diffs[idx].filename;
+        let Some(saved_hash) = saved.files.get(filename) else {
+            continue;
+        };
+        let current_hash = viewed_state::blob_hash_for_working_tree(Path::new(filename));
+        if current_hash == *saved_hash {
+            state.viewed_files.insert(idx);
+        }
+    }
+}
+
+/// Persist a single file's viewed/unviewed toggle to disk for `--save-viewed`.
+/// Called once per file, including per-file in bulk directory toggles —
+/// batching into a single write could be a followup if per-keystroke I/O
+/// ever becomes a perceptible cost.
+fn persist_viewed_toggle(viewed_state_path: &Option<PathBuf>, filename: &str, now_viewed: bool) {
+    let Some(path) = viewed_state_path else {
+        return;
+    };
+    let filename = filename.to_string();
+    if now_viewed {
+        let hash = viewed_state::blob_hash_for_working_tree(Path::new(&filename));
+        let _ = viewed_state::save_merged(path, |vs| {
+            vs.files.insert(filename, hash);
+        });
+    } else {
+        let _ = viewed_state::save_merged(path, |vs| {
+            vs.files.remove(&filename);
+        });
+    }
+}
+
 fn run_app_internal(
     options: DiffOptions,
     pr_info: Option<PrInfo>,
@@ -307,6 +385,7 @@ fn run_app_internal(
     let mut state = AppState::new(file_diffs, options.focus.as_deref());
     state.settings.wrap = options.wrap;
     state.set_vcs_name(backend.name());
+    init_viewed_state_persistence(&mut state, options.save_viewed, backend);
 
     // Set diff reference for annotation export context
     let diff_ref_str = if let Some(pr) = &pr_info {
@@ -409,6 +488,10 @@ fn run_app_internal(
             if let Some(ref pr) = pr_info {
                 sync_viewed_files_from_github(pr, &mut state);
             }
+
+            // Re-apply local --save-viewed state: disk may have been updated
+            // by another process, and file indices shifted after reload anyway.
+            apply_saved_viewed_state(&mut state);
         }
 
         if state.file_diffs.is_empty() {
@@ -1539,6 +1622,12 @@ fn run_app_internal(
                                                 state.viewed_files.insert(file_idx);
                                             }
 
+                                            persist_viewed_toggle(
+                                                &state.viewed_state_path,
+                                                &filename,
+                                                !was_viewed,
+                                            );
+
                                             // Fire off async API call if in PR mode
                                             if let Some(ref pr) = pr_info {
                                                 if was_viewed {
@@ -1581,6 +1670,15 @@ fn run_app_internal(
                                                 for idx in &child_indices {
                                                     state.viewed_files.insert(*idx);
                                                 }
+                                            }
+
+                                            for idx in &child_indices {
+                                                let filename = &state.file_diffs[*idx].filename;
+                                                persist_viewed_toggle(
+                                                    &state.viewed_state_path,
+                                                    filename,
+                                                    !all_viewed,
+                                                );
                                             }
 
                                             // Fire off async API calls if in PR mode
@@ -1649,6 +1747,12 @@ fn run_app_internal(
                                         ensure_sidebar_visible(&mut state, visible_height);
                                     }
                                 }
+
+                                persist_viewed_toggle(
+                                    &state.viewed_state_path,
+                                    &filename,
+                                    !was_viewed,
+                                );
 
                                 // Fire off async API call if in PR mode
                                 if let Some(ref pr) = pr_info {

--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -295,22 +295,23 @@ fn sync_viewed_files_from_github(pr_info: &PrInfo, state: &mut AppState) {
     }
 }
 
-/// Resolve local `--save-viewed` persistence for the current repo+branch and
-/// apply any previously-saved viewed state. No-op if `save_viewed` is false.
-/// Purely local — never touches GitHub/PR state.
+/// Resolve local `--save-viewed` persistence for the current repo+branch (or
+/// PR, when known) and apply any previously-saved viewed state. No-op if
+/// `save_viewed` is false. Purely local — never touches GitHub/PR state,
+/// though `pr_number` (when the caller is in PR mode) is used only as a
+/// stable local storage key so branch renames don't orphan saved state.
 fn init_viewed_state_persistence(
     state: &mut AppState,
     save_viewed: bool,
     backend: &dyn VcsBackend,
+    pr_number: Option<u64>,
 ) {
     if !save_viewed {
         return;
     }
 
     let branch = backend.get_current_branch().ok().flatten();
-    let path = branch
-        .as_deref()
-        .and_then(|b| viewed_state::resolve_path_for_current_repo(Some(b)));
+    let path = viewed_state::resolve_path_for_current_repo(branch.as_deref(), pr_number);
 
     let Some(path) = path else {
         eprintln!(
@@ -320,9 +321,7 @@ fn init_viewed_state_persistence(
     };
 
     if let Some(repo_viewed_dir) = path.parent() {
-        if let Some(branches) = viewed_state::list_local_branches() {
-            viewed_state::prune_stale_branches(repo_viewed_dir, &branches);
-        }
+        viewed_state::prune_stale_branches(repo_viewed_dir, 30);
     }
 
     state.viewed_state_path = Some(path);
@@ -385,7 +384,12 @@ fn run_app_internal(
     let mut state = AppState::new(file_diffs, options.focus.as_deref());
     state.settings.wrap = options.wrap;
     state.set_vcs_name(backend.name());
-    init_viewed_state_persistence(&mut state, options.save_viewed, backend);
+    init_viewed_state_persistence(
+        &mut state,
+        options.save_viewed,
+        backend,
+        pr_info.as_ref().map(|p| p.number),
+    );
 
     // Set diff reference for annotation export context
     let diff_ref_str = if let Some(pr) = &pr_info {

--- a/src/command/diff/git.rs
+++ b/src/command/diff/git.rs
@@ -537,6 +537,7 @@ mod tests {
             focus: None,
             origin: None,
             wrap: false,
+            save_viewed: false,
         };
 
         let diffs = load_file_diffs(&options, &backend);
@@ -609,6 +610,7 @@ mod tests {
             focus: None,
             origin: None,
             wrap: false,
+            save_viewed: false,
         };
 
         let diffs = load_file_diffs(&options, &backend);

--- a/src/command/diff/mod.rs
+++ b/src/command/diff/mod.rs
@@ -13,6 +13,7 @@ mod sticky_lines;
 mod text_edit;
 pub mod theme;
 mod types;
+pub mod viewed_state;
 mod watcher;
 
 use std::collections::HashSet;
@@ -36,6 +37,7 @@ pub struct DiffOptions {
     pub focus: Option<String>,
     pub origin: Option<String>,
     pub wrap: bool,
+    pub save_viewed: bool,
 }
 
 #[derive(Clone)]

--- a/src/command/diff/state.rs
+++ b/src/command/diff/state.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::time::SystemTime;
 
 use tree_sitter::{Parser, Tree};
@@ -227,6 +228,10 @@ pub struct AppState {
     pub total_added: usize,
     /// Total removed lines across all files in the current diff. Recomputed on reload.
     pub total_removed: usize,
+    /// On-disk path for `--save-viewed` local persistence. `None` means the
+    /// flag wasn't passed, or path resolution failed (e.g. detached HEAD) —
+    /// in either case, nothing is persisted.
+    pub viewed_state_path: Option<PathBuf>,
 }
 
 fn compute_total_line_stats(file_diffs: &[FileDiff]) -> (usize, usize) {
@@ -330,6 +335,7 @@ impl AppState {
             editor_rect: None,
             total_added,
             total_removed,
+            viewed_state_path: None,
         }
     }
 

--- a/src/command/diff/viewed_state.rs
+++ b/src/command/diff/viewed_state.rs
@@ -1,16 +1,20 @@
-//! Local, PR-independent persistence of viewed-file state for `lumen diff --watch`.
+//! Local persistence of viewed-file state for `lumen diff --watch` and PR review.
 //!
-//! State is keyed by `host/owner/repo/branch` (or a path-derived slug when there's
-//! no parseable origin remote) and content-hashed per file, so it survives
-//! quitting `--watch`, rebases, and force-pushes as long as the file's blob
-//! contents are unchanged. This module never talks to GitHub/`gh` — it is a
-//! purely local cache, opt-in via `--save-viewed`.
+//! State is keyed by `host/owner/repo/<session-key>` (or a path-derived slug when
+//! there's no parseable origin remote), where the session key is the PR number
+//! when known, else the current branch name, and content-hashed per file, so it
+//! survives quitting `--watch`, rebases, and force-pushes as long as the file's
+//! blob contents are unchanged. Keying by PR number (when available) also means
+//! a local branch rename can't orphan or destroy previously saved state. This
+//! module never talks to GitHub/`gh` — it is a purely local cache, opt-in via
+//! `--save-viewed`.
 
 use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
 
@@ -107,12 +111,6 @@ pub fn sanitize_branch_name(branch: &str) -> Option<String> {
     Some(branch.replace('/', "__"))
 }
 
-/// Reverse of `sanitize_branch_name`, for matching saved state files back to
-/// real branch names during pruning.
-fn desanitize_branch_name(sanitized: &str) -> String {
-    sanitized.replace("__", "/")
-}
-
 /// Build the `local__<sanitized-path>` fallback slug used when there's no
 /// parseable origin remote.
 fn local_fallback_slug(worktree_root: &Path) -> String {
@@ -136,15 +134,24 @@ fn state_base_dir_from(xdg_state_home: Option<&str>, home_dir: Option<PathBuf>) 
 
 /// Resolve the on-disk storage path for viewed state, given already-resolved
 /// origin info (or `None` for the local-slug fallback), the worktree root,
-/// and the current branch. Returns `None` if there's no branch to key on
+/// the current branch, and an optional PR number.
+///
+/// `pr_number` takes priority as the session key when present — state then
+/// converges on `pr-<n>.json` regardless of branch, surviving local branch
+/// renames (mirrors `annotation_store::resolve_annotation_store_path`'s
+/// PR-first key priority). When `pr_number` is `None`, falls back to the
+/// branch-keyed behavior, returning `None` if there's no branch to key on
 /// (e.g. detached HEAD) — callers should skip persistence entirely.
 pub fn resolve_storage_path(
     origin: Option<(&str, &str, &str)>,
     worktree_root: &Path,
     branch: Option<&str>,
+    pr_number: Option<u64>,
 ) -> Option<PathBuf> {
-    let branch = branch?;
-    let sanitized_branch = sanitize_branch_name(branch)?;
+    let session_key = match pr_number {
+        Some(n) => format!("pr-{}", n),
+        None => sanitize_branch_name(branch?)?,
+    };
 
     let (host, owner, repo) = match origin {
         Some((host, owner, repo)) => (host.to_string(), owner.to_string(), repo.to_string()),
@@ -159,7 +166,7 @@ pub fn resolve_storage_path(
     if !owner.is_empty() {
         path = path.join(owner);
     }
-    path = path.join(repo).join(format!("{}.json", sanitized_branch));
+    path = path.join(repo).join(format!("{}.json", session_key));
     Some(path)
 }
 
@@ -189,30 +196,12 @@ pub fn git_worktree_root() -> PathBuf {
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
 }
 
-/// List local branch names via `git for-each-ref`. Returns `None` (rather
-/// than an empty list) on any failure, so callers can distinguish "no
-/// branches" from "couldn't ask git" and skip pruning in the latter case —
-/// pruning off an empty-by-error list would wipe every saved branch.
-pub fn list_local_branches() -> Option<Vec<String>> {
-    let output = Command::new("git")
-        .args(["for-each-ref", "--format=%(refname:short)", "refs/heads"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    Some(
-        String::from_utf8_lossy(&output.stdout)
-            .lines()
-            .map(|l| l.trim().to_string())
-            .filter(|l| !l.is_empty())
-            .collect(),
-    )
-}
-
 /// Full resolution glue for the current repo: resolves origin remote and
 /// worktree root, then delegates to `resolve_storage_path`.
-pub fn resolve_path_for_current_repo(branch: Option<&str>) -> Option<PathBuf> {
+pub fn resolve_path_for_current_repo(
+    branch: Option<&str>,
+    pr_number: Option<u64>,
+) -> Option<PathBuf> {
     let origin = resolve_origin_host_owner_repo();
     let worktree_root = git_worktree_root();
     resolve_storage_path(
@@ -221,6 +210,7 @@ pub fn resolve_path_for_current_repo(branch: Option<&str>) -> Option<PathBuf> {
             .map(|(h, o, r)| (h.as_str(), o.as_str(), r.as_str())),
         &worktree_root,
         branch,
+        pr_number,
     )
 }
 
@@ -264,23 +254,30 @@ pub fn save_merged(path: &Path, updates: impl FnOnce(&mut ViewedState)) -> io::R
     Ok(())
 }
 
-/// Best-effort pruning of state files for branches that no longer exist.
-/// Swallows all I/O errors — pruning failures must never fail the command.
-pub fn prune_stale_branches(repo_viewed_dir: &Path, existing_branches: &[String]) {
+/// Best-effort pruning of state files whose mtime is older than
+/// `max_age_days`. Branch renames (`git branch -m`) no longer orphan or
+/// destroy saved state — age, not local branch existence, is the only
+/// pruning signal. Swallows all I/O errors — pruning failures must never
+/// fail the command.
+pub fn prune_stale_branches(repo_viewed_dir: &Path, max_age_days: u64) {
     let Ok(entries) = fs::read_dir(repo_viewed_dir) else {
+        return;
+    };
+    let Some(cutoff) = SystemTime::now().checked_sub(Duration::from_secs(max_age_days * 86_400))
+    else {
         return;
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-            continue;
-        };
         if path.extension().and_then(|e| e.to_str()) != Some("json") {
             continue;
         }
-        let branch = desanitize_branch_name(stem);
-        if !existing_branches.contains(&branch) {
-            let _ = fs::remove_file(&path);
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = fs::remove_file(&path);
+                }
+            }
         }
     }
 }
@@ -422,6 +419,7 @@ mod tests {
             Some(("github.com", "jnsahaj", "lumen")),
             &worktree,
             Some("feature/foo"),
+            None,
         )
         .unwrap();
 
@@ -431,7 +429,7 @@ mod tests {
     #[test]
     fn resolve_storage_path_falls_back_to_local_slug_without_origin() {
         let worktree = PathBuf::from("/home/user/code/scratch");
-        let path = resolve_storage_path(None, &worktree, Some("main")).unwrap();
+        let path = resolve_storage_path(None, &worktree, Some("main"), None).unwrap();
 
         let path_str = path.to_string_lossy();
         assert!(path_str.contains("local__"));
@@ -442,9 +440,55 @@ mod tests {
     #[test]
     fn resolve_storage_path_returns_none_without_branch() {
         let worktree = PathBuf::from("/home/user/code/lumen");
-        let path = resolve_storage_path(Some(("github.com", "a", "b")), &worktree, None);
+        let path = resolve_storage_path(Some(("github.com", "a", "b")), &worktree, None, None);
 
         assert_eq!(path, None);
+    }
+
+    #[test]
+    fn resolve_storage_path_uses_pr_number_when_present() {
+        let worktree = PathBuf::from("/home/user/code/lumen");
+        let path = resolve_storage_path(
+            Some(("github.com", "jnsahaj", "lumen")),
+            &worktree,
+            Some("feature/foo"),
+            Some(42),
+        )
+        .unwrap();
+
+        assert!(path.ends_with("lumen/viewed/github.com/jnsahaj/lumen/pr-42.json"));
+    }
+
+    #[test]
+    fn resolve_storage_path_pr_number_takes_priority_over_branch_rename() {
+        // Same PR, two different local branch names (as if renamed via
+        // `git branch -m`) must resolve to the same storage path.
+        let worktree = PathBuf::from("/home/user/code/lumen");
+        let origin = Some(("github.com", "jnsahaj", "lumen"));
+
+        let before =
+            resolve_storage_path(origin, &worktree, Some("regargeting-measurement"), Some(42));
+        let after = resolve_storage_path(
+            origin,
+            &worktree,
+            Some("feat/retargeting-efficacy-measurement"),
+            Some(42),
+        );
+
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn resolve_storage_path_pr_number_works_without_a_branch() {
+        let worktree = PathBuf::from("/home/user/code/lumen");
+        let path = resolve_storage_path(
+            Some(("github.com", "jnsahaj", "lumen")),
+            &worktree,
+            None,
+            Some(7),
+        );
+
+        assert!(path.unwrap().ends_with("pr-7.json"));
     }
 
     #[test]
@@ -564,26 +608,47 @@ mod tests {
         assert!(!leftover_tmp);
     }
 
-    #[test]
-    fn prune_stale_branches_removes_files_for_deleted_branches() {
-        let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("main.json"), "{}").unwrap();
-        fs::write(dir.path().join("feature__gone.json"), "{}").unwrap();
-
-        prune_stale_branches(dir.path(), &["main".to_string()]);
-
-        assert!(dir.path().join("main.json").exists());
-        assert!(!dir.path().join("feature__gone.json").exists());
+    fn set_mtime(path: &Path, when: SystemTime) {
+        let file = fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(when).unwrap();
     }
 
     #[test]
-    fn prune_stale_branches_keeps_existing_branches() {
+    fn prune_stale_branches_removes_files_older_than_max_age() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("feature__foo.json"), "{}").unwrap();
+        let stale = dir.path().join("regargeting-measurement.json");
+        fs::write(&stale, "{}").unwrap();
+        set_mtime(&stale, SystemTime::now() - Duration::from_secs(31 * 86_400));
 
-        prune_stale_branches(dir.path(), &["feature/foo".to_string()]);
+        prune_stale_branches(dir.path(), 30);
 
-        assert!(dir.path().join("feature__foo.json").exists());
+        assert!(!stale.exists());
+    }
+
+    #[test]
+    fn prune_stale_branches_keeps_files_within_max_age() {
+        let dir = TempDir::new().unwrap();
+        // A branch rename orphans the old key, but it's recent — pruning
+        // by branch existence used to delete this immediately; age-based
+        // pruning must not.
+        let renamed_away = dir.path().join("regargeting-measurement.json");
+        fs::write(&renamed_away, "{}").unwrap();
+
+        prune_stale_branches(dir.path(), 30);
+
+        assert!(renamed_away.exists());
+    }
+
+    #[test]
+    fn prune_stale_branches_ignores_non_json_files_regardless_of_age() {
+        let dir = TempDir::new().unwrap();
+        let other = dir.path().join("notes.txt");
+        fs::write(&other, "hello").unwrap();
+        set_mtime(&other, SystemTime::now() - Duration::from_secs(31 * 86_400));
+
+        prune_stale_branches(dir.path(), 30);
+
+        assert!(other.exists());
     }
 
     #[test]
@@ -592,6 +657,6 @@ mod tests {
         let missing = dir.path().join("does-not-exist");
 
         // Should not panic even though the directory doesn't exist.
-        prune_stale_branches(&missing, &[]);
+        prune_stale_branches(&missing, 30);
     }
 }

--- a/src/command/diff/viewed_state.rs
+++ b/src/command/diff/viewed_state.rs
@@ -1,0 +1,597 @@
+//! Local, PR-independent persistence of viewed-file state for `lumen diff --watch`.
+//!
+//! State is keyed by `host/owner/repo/branch` (or a path-derived slug when there's
+//! no parseable origin remote) and content-hashed per file, so it survives
+//! quitting `--watch`, rebases, and force-pushes as long as the file's blob
+//! contents are unchanged. This module never talks to GitHub/`gh` — it is a
+//! purely local cache, opt-in via `--save-viewed`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+const DELETED_SENTINEL: &str = "__deleted__";
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct HunkState {
+    pub hash: String,
+    pub hunks: Vec<usize>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct ViewedState {
+    pub schema: u32,
+    #[serde(default)]
+    pub files: BTreeMap<String, String>,
+    /// Reserved for future hunk-level persistence. Unused for now.
+    #[serde(default)]
+    pub hunks: BTreeMap<String, HunkState>,
+}
+
+impl ViewedState {
+    fn new() -> Self {
+        Self {
+            schema: SCHEMA_VERSION,
+            files: BTreeMap::new(),
+            hunks: BTreeMap::new(),
+        }
+    }
+}
+
+/// Compute the git blob hash of a file's current working-tree contents.
+/// Returns `DELETED_SENTINEL` if the file can't be read or hashed, so a
+/// deleted file never spuriously matches a previously-saved hash.
+pub fn blob_hash_for_working_tree(path: &Path) -> String {
+    match fs::read(path) {
+        Ok(bytes) => match git2::Oid::hash_object(git2::ObjectType::Blob, &bytes) {
+            Ok(oid) => oid.to_string(),
+            Err(_) => DELETED_SENTINEL.to_string(),
+        },
+        Err(_) => DELETED_SENTINEL.to_string(),
+    }
+}
+
+/// Parse a git remote URL into `(host, owner, repo)`. Handles the three
+/// common forms: `git@host:owner/repo.git`, `ssh://git@host/owner/repo.git`,
+/// and `https://host/owner/repo.git` (with or without a trailing `.git`).
+pub fn parse_remote_url(url: &str) -> Option<(String, String, String)> {
+    let url = url.trim();
+    let url = url.strip_suffix(".git").unwrap_or(url);
+
+    let path_part = if let Some(rest) = url.strip_prefix("ssh://") {
+        // ssh://[user@]host[:port]/owner/repo
+        let rest = rest.split_once('@').map(|(_, r)| r).unwrap_or(rest);
+        let (host_and_port, path) = rest.split_once('/')?;
+        let host = host_and_port.split(':').next()?;
+        return split_owner_repo(path).map(|(owner, repo)| (host.to_string(), owner, repo));
+    } else if let Some(rest) = url.strip_prefix("https://") {
+        rest
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        rest
+    } else if let Some(at_pos) = url.find('@') {
+        // scp-like: git@host:owner/repo(.git)
+        let rest = &url[at_pos + 1..];
+        let (host, path) = rest.split_once(':')?;
+        return split_owner_repo(path).map(|(owner, repo)| (host.to_string(), owner, repo));
+    } else {
+        return None;
+    };
+
+    let (host, path) = path_part.split_once('/')?;
+    split_owner_repo(path).map(|(owner, repo)| (host.to_string(), owner, repo))
+}
+
+fn split_owner_repo(path: &str) -> Option<(String, String)> {
+    let path = path.trim_matches('/');
+    let parts: Vec<&str> = path.split('/').collect();
+    if parts.len() < 2 || parts[0].is_empty() || parts[1].is_empty() {
+        return None;
+    }
+    Some((parts[0].to_string(), parts[1].to_string()))
+}
+
+/// Sanitize a branch name for use as a filesystem path component.
+/// Returns `None` for names containing `..` path traversal segments.
+pub fn sanitize_branch_name(branch: &str) -> Option<String> {
+    if branch.is_empty() {
+        return None;
+    }
+    if branch.split('/').any(|segment| segment == "..") {
+        return None;
+    }
+    Some(branch.replace('/', "__"))
+}
+
+/// Reverse of `sanitize_branch_name`, for matching saved state files back to
+/// real branch names during pruning.
+fn desanitize_branch_name(sanitized: &str) -> String {
+    sanitized.replace("__", "/")
+}
+
+/// Build the `local__<sanitized-path>` fallback slug used when there's no
+/// parseable origin remote.
+fn local_fallback_slug(worktree_root: &Path) -> String {
+    let raw = worktree_root.to_string_lossy();
+    let sanitized = raw.replace(['/', '\\'], "__");
+    format!("local__{}", sanitized.trim_start_matches("__"))
+}
+
+/// Base directory for lumen's state files, respecting `$XDG_STATE_HOME` when set.
+pub fn state_base_dir() -> PathBuf {
+    let xdg = std::env::var("XDG_STATE_HOME").ok();
+    state_base_dir_from(xdg.as_deref(), dirs::home_dir())
+}
+
+fn state_base_dir_from(xdg_state_home: Option<&str>, home_dir: Option<PathBuf>) -> PathBuf {
+    match xdg_state_home {
+        Some(dir) if !dir.is_empty() => PathBuf::from(dir),
+        _ => home_dir.unwrap_or_default().join(".local/state"),
+    }
+}
+
+/// Resolve the on-disk storage path for viewed state, given already-resolved
+/// origin info (or `None` for the local-slug fallback), the worktree root,
+/// and the current branch. Returns `None` if there's no branch to key on
+/// (e.g. detached HEAD) — callers should skip persistence entirely.
+pub fn resolve_storage_path(
+    origin: Option<(&str, &str, &str)>,
+    worktree_root: &Path,
+    branch: Option<&str>,
+) -> Option<PathBuf> {
+    let branch = branch?;
+    let sanitized_branch = sanitize_branch_name(branch)?;
+
+    let (host, owner, repo) = match origin {
+        Some((host, owner, repo)) => (host.to_string(), owner.to_string(), repo.to_string()),
+        None => (
+            "local".to_string(),
+            String::new(),
+            local_fallback_slug(worktree_root),
+        ),
+    };
+
+    let mut path = state_base_dir().join("lumen").join("viewed").join(host);
+    if !owner.is_empty() {
+        path = path.join(owner);
+    }
+    path = path.join(repo).join(format!("{}.json", sanitized_branch));
+    Some(path)
+}
+
+/// Shell out to `git remote get-url origin` and parse it into `(host, owner, repo)`.
+/// Returns `None` when there's no origin remote or it isn't parseable.
+pub fn resolve_origin_host_owner_repo() -> Option<(String, String, String)> {
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    parse_remote_url(&url)
+}
+
+/// Shell out to `git rev-parse --show-toplevel` to find the worktree root,
+/// falling back to the current directory if that fails.
+pub fn git_worktree_root() -> PathBuf {
+    Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| PathBuf::from(String::from_utf8_lossy(&o.stdout).trim()))
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
+}
+
+/// List local branch names via `git for-each-ref`. Returns `None` (rather
+/// than an empty list) on any failure, so callers can distinguish "no
+/// branches" from "couldn't ask git" and skip pruning in the latter case —
+/// pruning off an empty-by-error list would wipe every saved branch.
+pub fn list_local_branches() -> Option<Vec<String>> {
+    let output = Command::new("git")
+        .args(["for-each-ref", "--format=%(refname:short)", "refs/heads"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect(),
+    )
+}
+
+/// Full resolution glue for the current repo: resolves origin remote and
+/// worktree root, then delegates to `resolve_storage_path`.
+pub fn resolve_path_for_current_repo(branch: Option<&str>) -> Option<PathBuf> {
+    let origin = resolve_origin_host_owner_repo();
+    let worktree_root = git_worktree_root();
+    resolve_storage_path(
+        origin
+            .as_ref()
+            .map(|(h, o, r)| (h.as_str(), o.as_str(), r.as_str())),
+        &worktree_root,
+        branch,
+    )
+}
+
+/// Load viewed state from disk. Never fails: any read/parse error, missing
+/// file, or schema mismatch yields a fresh default state.
+pub fn load(path: &Path) -> ViewedState {
+    match fs::read_to_string(path) {
+        Ok(contents) => match serde_json::from_str::<ViewedState>(&contents) {
+            Ok(state) if state.schema == SCHEMA_VERSION => state,
+            _ => ViewedState::new(),
+        },
+        Err(_) => ViewedState::new(),
+    }
+}
+
+/// Re-read the on-disk state, apply `updates`, and atomically write the
+/// result back. Re-reading fresh (rather than trusting an in-memory copy)
+/// means concurrent `lumen diff --watch` sessions merge rather than clobber
+/// each other's saved entries.
+pub fn save_merged(path: &Path, updates: impl FnOnce(&mut ViewedState)) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
+    fs::create_dir_all(parent)?;
+
+    let mut state = load(path);
+    updates(&mut state);
+
+    let json = serde_json::to_string_pretty(&state).map_err(io::Error::other)?;
+
+    let tmp_name = format!(
+        ".{}.tmp.{}",
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("viewed"),
+        std::process::id()
+    );
+    let tmp_path = parent.join(tmp_name);
+    fs::write(&tmp_path, json)?;
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+/// Best-effort pruning of state files for branches that no longer exist.
+/// Swallows all I/O errors — pruning failures must never fail the command.
+pub fn prune_stale_branches(repo_viewed_dir: &Path, existing_branches: &[String]) {
+    let Ok(entries) = fs::read_dir(repo_viewed_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let branch = desanitize_branch_name(stem);
+        if !existing_branches.contains(&branch) {
+            let _ = fs::remove_file(&path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn blob_hash_is_stable_for_same_content() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("a.txt");
+        fs::write(&file, b"hello world").unwrap();
+
+        let first = blob_hash_for_working_tree(&file);
+        let second = blob_hash_for_working_tree(&file);
+
+        assert_eq!(first, second);
+        assert_ne!(first, DELETED_SENTINEL);
+    }
+
+    #[test]
+    fn blob_hash_differs_for_different_content() {
+        let dir = TempDir::new().unwrap();
+        let file_a = dir.path().join("a.txt");
+        let file_b = dir.path().join("b.txt");
+        fs::write(&file_a, b"hello world").unwrap();
+        fs::write(&file_b, b"goodbye world").unwrap();
+
+        assert_ne!(
+            blob_hash_for_working_tree(&file_a),
+            blob_hash_for_working_tree(&file_b)
+        );
+    }
+
+    #[test]
+    fn blob_hash_returns_sentinel_for_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist.txt");
+
+        assert_eq!(blob_hash_for_working_tree(&missing), DELETED_SENTINEL);
+    }
+
+    #[test]
+    fn parse_remote_url_handles_https() {
+        let parsed = parse_remote_url("https://github.com/jnsahaj/lumen.git");
+        assert_eq!(
+            parsed,
+            Some((
+                "github.com".to_string(),
+                "jnsahaj".to_string(),
+                "lumen".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_remote_url_handles_https_without_git_suffix() {
+        let parsed = parse_remote_url("https://gitlab.example.com/owner/repo");
+        assert_eq!(
+            parsed,
+            Some((
+                "gitlab.example.com".to_string(),
+                "owner".to_string(),
+                "repo".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_remote_url_handles_scp_like_ssh() {
+        let parsed = parse_remote_url("git@github.com:jnsahaj/lumen.git");
+        assert_eq!(
+            parsed,
+            Some((
+                "github.com".to_string(),
+                "jnsahaj".to_string(),
+                "lumen".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_remote_url_handles_ssh_url_form() {
+        let parsed = parse_remote_url("ssh://git@github.com/jnsahaj/lumen.git");
+        assert_eq!(
+            parsed,
+            Some((
+                "github.com".to_string(),
+                "jnsahaj".to_string(),
+                "lumen".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_remote_url_handles_ssh_url_with_port() {
+        let parsed = parse_remote_url("ssh://git@example.com:2222/owner/repo.git");
+        assert_eq!(
+            parsed,
+            Some((
+                "example.com".to_string(),
+                "owner".to_string(),
+                "repo".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_remote_url_rejects_unparseable_input() {
+        assert_eq!(parse_remote_url("not a url at all"), None);
+        assert_eq!(parse_remote_url("https://github.com/onlyowner"), None);
+    }
+
+    #[test]
+    fn sanitize_branch_name_replaces_slashes() {
+        assert_eq!(
+            sanitize_branch_name("feature/foo-bar"),
+            Some("feature__foo-bar".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_branch_name_rejects_path_traversal() {
+        assert_eq!(sanitize_branch_name("../etc/passwd"), None);
+        assert_eq!(sanitize_branch_name("feature/../evil"), None);
+    }
+
+    #[test]
+    fn sanitize_branch_name_rejects_empty() {
+        assert_eq!(sanitize_branch_name(""), None);
+    }
+
+    #[test]
+    fn resolve_storage_path_uses_origin_when_available() {
+        let worktree = PathBuf::from("/home/user/code/lumen");
+        let path = resolve_storage_path(
+            Some(("github.com", "jnsahaj", "lumen")),
+            &worktree,
+            Some("feature/foo"),
+        )
+        .unwrap();
+
+        assert!(path.ends_with("lumen/viewed/github.com/jnsahaj/lumen/feature__foo.json"));
+    }
+
+    #[test]
+    fn resolve_storage_path_falls_back_to_local_slug_without_origin() {
+        let worktree = PathBuf::from("/home/user/code/scratch");
+        let path = resolve_storage_path(None, &worktree, Some("main")).unwrap();
+
+        let path_str = path.to_string_lossy();
+        assert!(path_str.contains("local__"));
+        assert!(path_str.contains("home__user__code__scratch"));
+        assert!(path_str.ends_with("main.json"));
+    }
+
+    #[test]
+    fn resolve_storage_path_returns_none_without_branch() {
+        let worktree = PathBuf::from("/home/user/code/lumen");
+        let path = resolve_storage_path(Some(("github.com", "a", "b")), &worktree, None);
+
+        assert_eq!(path, None);
+    }
+
+    #[test]
+    fn state_base_dir_prefers_xdg_state_home_when_set() {
+        let base = state_base_dir_from(Some("/custom/state"), Some(PathBuf::from("/home/user")));
+        assert_eq!(base, PathBuf::from("/custom/state"));
+    }
+
+    #[test]
+    fn state_base_dir_falls_back_to_home_local_state() {
+        let base = state_base_dir_from(None, Some(PathBuf::from("/home/user")));
+        assert_eq!(base, PathBuf::from("/home/user/.local/state"));
+    }
+
+    #[test]
+    fn state_base_dir_ignores_empty_xdg_state_home() {
+        let base = state_base_dir_from(Some(""), Some(PathBuf::from("/home/user")));
+        assert_eq!(base, PathBuf::from("/home/user/.local/state"));
+    }
+
+    #[test]
+    fn load_missing_file_returns_default_state() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nope.json");
+
+        let state = load(&path);
+
+        assert_eq!(state.schema, SCHEMA_VERSION);
+        assert!(state.files.is_empty());
+    }
+
+    #[test]
+    fn load_schema_mismatch_returns_default_state() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.json");
+        fs::write(&path, r#"{"schema":999,"files":{"a.txt":"deadbeef"}}"#).unwrap();
+
+        let state = load(&path);
+
+        assert_eq!(state.schema, SCHEMA_VERSION);
+        assert!(state.files.is_empty());
+    }
+
+    #[test]
+    fn load_malformed_json_returns_default_state() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.json");
+        fs::write(&path, "{ not json").unwrap();
+
+        let state = load(&path);
+
+        assert_eq!(state, ViewedState::new());
+    }
+
+    #[test]
+    fn save_merged_roundtrips_through_load() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("branch.json");
+
+        save_merged(&path, |vs| {
+            vs.files.insert("a.txt".to_string(), "hash-a".to_string());
+        })
+        .unwrap();
+
+        let loaded = load(&path);
+        assert_eq!(loaded.files.get("a.txt"), Some(&"hash-a".to_string()));
+    }
+
+    #[test]
+    fn save_merged_merges_instead_of_replacing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("branch.json");
+
+        save_merged(&path, |vs| {
+            vs.files.insert("a.txt".to_string(), "hash-a".to_string());
+        })
+        .unwrap();
+
+        save_merged(&path, |vs| {
+            vs.files.insert("b.txt".to_string(), "hash-b".to_string());
+        })
+        .unwrap();
+
+        let loaded = load(&path);
+        assert_eq!(loaded.files.get("a.txt"), Some(&"hash-a".to_string()));
+        assert_eq!(loaded.files.get("b.txt"), Some(&"hash-b".to_string()));
+        assert_eq!(loaded.files.len(), 2);
+    }
+
+    #[test]
+    fn save_merged_creates_parent_directories() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested").join("dirs").join("branch.json");
+
+        save_merged(&path, |vs| {
+            vs.files.insert("a.txt".to_string(), "hash-a".to_string());
+        })
+        .unwrap();
+
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn save_merged_leaves_no_tmp_files_behind() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("branch.json");
+
+        save_merged(&path, |vs| {
+            vs.files.insert("a.txt".to_string(), "hash-a".to_string());
+        })
+        .unwrap();
+
+        let leftover_tmp = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".tmp."));
+        assert!(!leftover_tmp);
+    }
+
+    #[test]
+    fn prune_stale_branches_removes_files_for_deleted_branches() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("main.json"), "{}").unwrap();
+        fs::write(dir.path().join("feature__gone.json"), "{}").unwrap();
+
+        prune_stale_branches(dir.path(), &["main".to_string()]);
+
+        assert!(dir.path().join("main.json").exists());
+        assert!(!dir.path().join("feature__gone.json").exists());
+    }
+
+    #[test]
+    fn prune_stale_branches_keeps_existing_branches() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("feature__foo.json"), "{}").unwrap();
+
+        prune_stale_branches(dir.path(), &["feature/foo".to_string()]);
+
+        assert!(dir.path().join("feature__foo.json").exists());
+    }
+
+    #[test]
+    fn prune_stale_branches_swallows_missing_dir_error() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist");
+
+        // Should not panic even though the directory doesn't exist.
+        prune_stale_branches(&missing, &[]);
+    }
+}

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -147,6 +147,11 @@ pub enum Commands {
         /// Soft-wrap long diff lines instead of scrolling horizontally
         #[arg(long)]
         wrap: bool,
+
+        /// Persist viewed-file state locally across sessions, keyed by repo+branch
+        /// and content hash (survives quitting `--watch` and rebases)
+        #[arg(long = "save-viewed")]
+        save_viewed: bool,
     },
     /// Interactively configure Lumen (provider, API key)
     Configure,

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,7 @@ async fn run() -> Result<(), LumenError> {
             focus,
             origin,
             wrap,
+            save_viewed,
         } => {
             let options = command::diff::DiffOptions {
                 reference,
@@ -145,6 +146,7 @@ async fn run() -> Result<(), LumenError> {
                 focus,
                 origin,
                 wrap: wrap || config.wrap.unwrap_or(false),
+                save_viewed,
             };
             command::diff::run_diff_ui(options, backend.as_ref())?;
         }


### PR DESCRIPTION
Adds an opt-in `--save-viewed` flag to `lumen diff` that persists viewed-file state across sessions, entirely locally — no GitHub involvement, works the same whether or not the branch has an associated PR.

State is keyed by repo + branch + each file's content hash, so it survives quitting `--watch` and rebases (a file only shows as viewed again if its contents still match what you last saw). Writes happen incrementally on each toggle (survives hard kills, not just clean exits) and merge with any existing on-disk state rather than replacing it, so concurrent sessions or `--file`-scoped runs don't clobber each other. State files live under `$XDG_STATE_HOME/lumen/viewed/` (or `~/.local/state/lumen/viewed/` if unset).

This is scoped to file-level persistence for now — the schema reserves a `hunks` field for future hunk-level persistence as a natural followup.

Related to #135 (which is about persisting annotation content, not viewed-state) and builds on the reload-invalidation behavior from #75.