### PR TITLE
fix: Groq models with unlisted names (e.g. openai/gpt-oss-120b) fall back to Ollama

### DIFF
--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -49,7 +49,7 @@ impl LumenProvider {
     ) -> Result<Self, LumenError> {
         let (backend, provider_name) = match provider_type {
             // Custom endpoint providers (OpenCode Zen, OpenRouter, Vercel) - use ServiceTargetResolver
-            ProviderType::OpencodeZen | ProviderType::Openrouter | ProviderType::Vercel => {
+            ProviderType::OpencodeZen | ProviderType::Openrouter | ProviderType::Vercel | ProviderType::Groq => {
                 let defaults = ProviderInfo::for_provider(provider_type);
                 let config = match provider_type {
                     ProviderType::OpencodeZen => CustomProviderConfig {
@@ -65,6 +65,11 @@ impl LumenProvider {
                     ProviderType::Vercel => CustomProviderConfig {
                         // Trailing slash is required for URL joining to work correctly
                         endpoint: "https://ai-gateway.vercel.sh/v1/",
+                        env_key: defaults.env_key,
+                        adapter_kind: AdapterKind::OpenAI,
+                    },
+                    ProviderType::Groq => CustomProviderConfig {
+                        endpoint: "https://api.groq.com/openai/v1/",
                         env_key: defaults.env_key,
                         adapter_kind: AdapterKind::OpenAI,
                     },


### PR DESCRIPTION
Groq models that aren't in genai's hardcoded `groq::MODELS` list get misdetected and silently routed to the Ollama adapter, which then tries to hit `localhost:11434` and fails.

Repro:
```
lumen -p groq -k "$GROQ_API_KEY" -m "openai/gpt-oss-120b" draft
error: AI request failed: Web call failed for model 'openai/gpt-oss-120b (adapter: Ollama)'.
Cause: Reqwest error: error sending request for url (http://localhost:11434/v1/chat/completions)
```

`llama-3.3-70b-versatile` works fine, `openai/gpt-oss-120b` doesn't.

Fix: route Groq through the same `ServiceTargetResolver` path already used for OpenCode Zen / OpenRouter / Vercel, forcing `AdapterKind::OpenAI` with Groq's endpoint instead of letting genai guess. Groq's API is OpenAI-compatible anyway, so this is safe and matches the existing pattern for the other custom providers.

Tested locally, builds and works.