### PR TITLE
fix(vcs): use merge-base semantics for range-to-working-tree diffs

### DIFF
--- a/src/command/diff/git.rs
+++ b/src/command/diff/git.rs
@@ -62,7 +62,17 @@ impl DiffRefs {
                 }
             }
             Some(CommitReference::RangeToWorkingTree { from }) => {
-                DiffRefs::RangeToWorkingTree { from: from.clone() }
+                // Get merge-base against the working tree's parent, matching
+                // the three-dot semantics used for `TripleDots` above.
+                let head_ref = backend.working_copy_parent_ref();
+                let merge_base = backend.get_merge_base(from, head_ref).unwrap_or_else(|e| {
+                    eprintln!(
+                        "Warning: failed to find merge-base for {}...{}: {}. Using '{}' as base.",
+                        from, head_ref, e, from
+                    );
+                    from.clone()
+                });
+                DiffRefs::RangeToWorkingTree { from: merge_base }
             }
         }
     }
@@ -640,6 +650,92 @@ mod tests {
         let committed = diffs.iter().find(|d| d.filename == "committed.txt").unwrap();
         assert_eq!(committed.old_content, "");
         assert_eq!(committed.new_content, "committed\n");
+
+        let _ = std::env::set_current_dir(&original);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_load_file_diffs_range_to_working_tree_uses_merge_base_for_diverging_branches() {
+        let _lock = crate::vcs::test_utils::cwd_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = make_temp_dir("git-diff-range-to-wt-diverging");
+        let original = std::env::current_dir().expect("get cwd");
+
+        git(&dir, &["init"]);
+        git(&dir, &["config", "user.email", "test@example.com"]);
+        git(&dir, &["config", "user.name", "Test User"]);
+
+        // Base commit shared by both branches.
+        fs::write(dir.join("base.txt"), "base\n").expect("write base");
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-m", "base"]);
+
+        // Diverge: "feature" branch gets its own unique commit.
+        git(&dir, &["checkout", "-b", "feature"]);
+        fs::write(dir.join("feature_only.txt"), "feature\n").expect("write feature_only");
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-m", "feature-only commit"]);
+
+        // Back on main, diverge with a different unique commit not reachable
+        // from "feature" — this is what merge-base(feature, HEAD)..HEAD sees.
+        git(&dir, &["checkout", "main"]);
+        fs::write(dir.join("main_only.txt"), "main content\n").expect("write main_only");
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-m", "main-only commit"]);
+
+        // Uncommitted working-tree changes on top of HEAD (main).
+        fs::write(dir.join("uncommitted.txt"), "uncommitted\n").expect("write uncommitted");
+        fs::write(dir.join("base.txt"), "base modified\n").expect("modify base");
+
+        std::env::set_current_dir(&dir).expect("set cwd");
+
+        let backend = crate::vcs::GitBackend::from_cwd().expect("should open repo");
+        let options = super::super::DiffOptions {
+            reference: Some(
+                crate::commit_reference::CommitReference::RangeToWorkingTree {
+                    from: "feature".to_string(),
+                },
+            ),
+            pr: None,
+            detect_pr: false,
+            file: None,
+            watch: false,
+            theme: None,
+            stacked: false,
+            focus: None,
+            origin: None,
+            wrap: false,
+        };
+
+        let diffs = load_file_diffs(&options, &backend);
+        let filenames: Vec<&str> = diffs.iter().map(|d| d.filename.as_str()).collect();
+
+        // Merge-base semantics: only the delta unique to HEAD (main-only commit)
+        // plus working-tree changes should show up. The "feature" branch's own
+        // divergent commit must NOT leak in — that would be two-dot/direct-diff
+        // semantics, which is the bug this test guards against.
+        assert!(
+            !filenames.contains(&"feature_only.txt"),
+            "feature branch's divergent commit should be excluded under merge-base semantics, got: {:?}",
+            filenames
+        );
+        assert!(
+            filenames.contains(&"main_only.txt"),
+            "should include HEAD's own committed change since merge-base, got: {:?}",
+            filenames
+        );
+        assert!(
+            filenames.contains(&"uncommitted.txt"),
+            "should include untracked working tree file, got: {:?}",
+            filenames
+        );
+        assert!(
+            filenames.contains(&"base.txt"),
+            "should include modified working tree file, got: {:?}",
+            filenames
+        );
 
         let _ = std::env::set_current_dir(&original);
         let _ = fs::remove_dir_all(&dir);

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ async fn run() -> Result<(), LumenError> {
                     Some(CommitReference::RangeToWorkingTree { from }) => {
                         let head_ref = backend.working_copy_parent_ref();
                         let range_diff = backend
-                            .get_range_diff(&from, head_ref, false)
+                            .get_range_diff(&from, head_ref, true)
                             .unwrap_or_default();
                         let wt_diff = backend.get_working_tree_diff(false).unwrap_or_default();
                         let combined = format!("{}{}", range_diff, wt_diff);

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -999,6 +999,75 @@ mod tests {
     }
 
     #[test]
+    fn test_get_range_diff_three_dot_uses_merge_base_for_diverging_branches() {
+        use crate::vcs::test_utils::{git, make_temp_dir};
+        use std::fs;
+
+        let _lock = crate::vcs::test_utils::cwd_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = make_temp_dir("git-range-three-dot-diverging");
+        let original = std::env::current_dir().expect("get cwd");
+
+        git(&dir, &["init"]);
+        git(&dir, &["config", "user.email", "test@example.com"]);
+        git(&dir, &["config", "user.name", "Test User"]);
+
+        // Base commit shared by both branches.
+        fs::write(dir.join("base.txt"), "base\n").expect("write base");
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-m", "base"]);
+
+        // Diverge: "feature" branch gets its own unique commit.
+        git(&dir, &["checkout", "-b", "feature"]);
+        fs::write(dir.join("feature_only.txt"), "feature\n").expect("write feature_only");
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-m", "feature-only commit"]);
+
+        // Back on main, diverge with a different unique commit not reachable
+        // from "feature".
+        git(&dir, &["checkout", "main"]);
+        fs::write(dir.join("main_only.txt"), "main content\n").expect("write main_only");
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-m", "main-only commit"]);
+
+        std::env::set_current_dir(&dir).expect("set cwd");
+
+        let backend = GitBackend::from_cwd().expect("should open repo");
+
+        // Two-dot: diffs feature's tree directly against main's tree, so it
+        // picks up feature's own divergent file as a removal.
+        let diff_2dot = backend
+            .get_range_diff("feature", "main", false)
+            .expect("should get two-dot diff");
+        assert!(
+            diff_2dot.contains("feature_only.txt"),
+            "two-dot diff should include feature's divergent file, got: {}",
+            diff_2dot
+        );
+
+        // Three-dot: diffs merge-base(feature, main)..main, so feature's own
+        // divergent commit must not leak in — only main's unique commit shows.
+        let diff_3dot = backend
+            .get_range_diff("feature", "main", true)
+            .expect("should get three-dot diff");
+        assert!(
+            !diff_3dot.contains("feature_only.txt"),
+            "three-dot diff should exclude feature's divergent file, got: {}",
+            diff_3dot
+        );
+        assert!(
+            diff_3dot.contains("main_only.txt"),
+            "three-dot diff should include main's own committed change, got: {}",
+            diff_3dot
+        );
+
+        // Cleanup
+        let _ = std::env::set_current_dir(&original);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn test_range_diff_excludes_lock_files() {
         use crate::vcs::test_utils::{git, make_temp_dir};
         use std::fs;


### PR DESCRIPTION
`<from>..-` diffs `from` directly against HEAD (two-dot) before unioning
with working-tree changes, instead of using merge-base (three-dot)
semantics like `<from>...<to>` does. This means commits made on `from`
after it diverged from HEAD incorrectly show up in the diff.

Fixes both the `lumen explain` path (src/main.rs) and the `lumen diff`
TUI path (DiffRefs::from_options), mirroring the merge-base handling
already used by the `TripleDots` arm in each. Adds regression tests
covering diverging branches in both src/vcs/git.rs and
src/command/diff/git.rs.