### PR TITLE
diff: Copy and clear annotations with Shift-y/Y

### DIFF
--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -784,6 +784,29 @@ fn run_app_internal(
                                     }
                                     active_modal = None;
                                 }
+                                ModalResult::AnnotationCopyDeleteAll => {
+                                    let formatted = state.format_annotations_for_export();
+                                    let copy_result = arboard::Clipboard::new()
+                                        .and_then(|mut clipboard| clipboard.set_text(&formatted));
+                                    match copy_result {
+                                        Ok(()) => {
+                                            state.annotations.clear();
+                                            active_modal = None;
+                                        }
+                                        Err(e) => {
+                                            if let Some(ref mut modal) = active_modal {
+                                                if let ModalContent::Annotations {
+                                                    error_message,
+                                                    ..
+                                                } = &mut modal.content
+                                                {
+                                                    *error_message =
+                                                        Some(format!("Failed to copy: {}", e));
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                                 ModalResult::AnnotationExport(filename) => {
                                     // Write annotations to file
                                     let formatted = state.format_annotations_for_export();

--- a/src/command/diff/render/modal.rs
+++ b/src/command/diff/render/modal.rs
@@ -98,6 +98,7 @@ pub enum ModalResult {
     AnnotationEdit { annotation_id: u64 },
     AnnotationDelete { annotation_id: u64 },
     AnnotationCopyAll,
+    AnnotationCopyDeleteAll,
     AnnotationExport(String),
 }
 
@@ -890,6 +891,9 @@ impl Modal {
                 Span::styled("y", Style::default().fg(t.ui.text_muted)),
                 Span::styled(" copy  ", Style::default().fg(t.ui.text_muted)),
                 Span::styled("│  ", Style::default().fg(t.ui.border_unfocused)),
+                Span::styled("Y", Style::default().fg(t.ui.text_muted)),
+                Span::styled(" copy+del  ", Style::default().fg(t.ui.text_muted)),
+                Span::styled("│  ", Style::default().fg(t.ui.border_unfocused)),
                 Span::styled("o", Style::default().fg(t.ui.text_muted)),
                 Span::styled(" export", Style::default().fg(t.ui.text_muted)),
             ])
@@ -1279,6 +1283,10 @@ impl Modal {
                                 annotation_id: ann.id,
                             }
                         }),
+                        KeyCode::Char('Y') => Some(ModalResult::AnnotationCopyDeleteAll),
+                        KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                            Some(ModalResult::AnnotationCopyDeleteAll)
+                        }
                         KeyCode::Char('y') => Some(ModalResult::AnnotationCopyAll),
                         KeyCode::Char('o') => {
                             *export_input = Some(String::from("annotations.txt"));


### PR DESCRIPTION
# Summary

I like running lumen as a long-running process with file watching, annotating feedback to my agent and marking files and
hunks as reviewed as I work through the diff. Starting a new feedback round currently requires copying the annotations
with `y`, then deleting each one individually.

I could instead use a short-lived lumen session with a separate commit or diff for each feedback round, but I would then
need to squash all the intermediate commits once I am happy with the agent's code since I like to keep commit history
clean.

To fix this inconvenience, this PR adds a `Shift-y`/`Y` action that copies all annotations and clears them in one step
:)
