### PR TITLE
nix: a collection of 3 improvements to the flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1768113825,
-        "narHash": "sha256-f09fAifGPEuRrz1DFY910jexq0DaBuQBbq7WcxQIUgs=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "55106e04d905c6a7726d0f6be77ed39a99f66a61",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -57,26 +36,8 @@
     },
     "root": {
       "inputs": {
-        "fenix": "fenix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1768083390,
-        "narHash": "sha256-TGWPJq2mXwxfAe83iZ18DIqXC4sOSj7RkW9b59h6Ox4=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "e42e8ff582ba12a88b6845525d08b6428e6d0fb9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768127708,
-        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
@@ -15,21 +11,12 @@
       self,
       nixpkgs,
       flake-utils,
-      fenix,
       ...
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = import nixpkgs { inherit system; };
-        rustToolchain = fenix.packages.${system}.stable.withComponents [
-          "cargo"
-          "clippy"
-          "rustc"
-          "rustfmt"
-          "rust-src"
-        ];
-        rust-analyzer = fenix.packages.${system}.rust-analyzer;
       in
       {
         packages = {
@@ -57,8 +44,11 @@
 
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = [
-            rustToolchain
-            rust-analyzer
+            pkgs.cargo
+            pkgs.clippy
+            pkgs.rust-analyzer
+            pkgs.rustc
+            pkgs.rustfmt
             pkgs.pkg-config
             pkgs.perl
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -10,55 +10,64 @@
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-    fenix,
-    ...
-  }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs {inherit system;};
-      rustToolchain = fenix.packages.${system}.stable.withComponents [
-        "cargo"
-        "clippy"
-        "rustc"
-        "rustfmt"
-        "rust-src"
-      ];
-      rust-analyzer = fenix.packages.${system}.rust-analyzer;
-    in {
-      packages = {
-        lumen = let
-          manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
-        in
-          pkgs.rustPlatform.buildRustPackage {
-            pname = manifest.name;
-            version = manifest.version;
-
-            cargoLock.lockFile = ./Cargo.lock;
-
-            src = pkgs.lib.cleanSource ./.;
-
-            nativeBuildInputs = [pkgs.pkg-config pkgs.perl];
-            buildInputs = [pkgs.openssl];
-            doCheck = false;
-          };
-        default = self.packages.${system}.lumen;
-      };
-
-      devShells.default = pkgs.mkShell {
-        nativeBuildInputs = [
-          rustToolchain
-          rust-analyzer
-          pkgs.pkg-config
-          pkgs.perl
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      fenix,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        rustToolchain = fenix.packages.${system}.stable.withComponents [
+          "cargo"
+          "clippy"
+          "rustc"
+          "rustfmt"
+          "rust-src"
         ];
-        buildInputs = [
-          pkgs.openssl
-        ];
-      };
-    })
+        rust-analyzer = fenix.packages.${system}.rust-analyzer;
+      in
+      {
+        packages = {
+          lumen =
+            let
+              manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+            in
+            pkgs.rustPlatform.buildRustPackage {
+              pname = manifest.name;
+              version = manifest.version;
+
+              cargoLock.lockFile = ./Cargo.lock;
+
+              src = pkgs.lib.cleanSource ./.;
+
+              nativeBuildInputs = [
+                pkgs.pkg-config
+                pkgs.perl
+              ];
+              buildInputs = [ pkgs.openssl ];
+              doCheck = false;
+            };
+          default = self.packages.${system}.lumen;
+        };
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [
+            rustToolchain
+            rust-analyzer
+            pkgs.pkg-config
+            pkgs.perl
+          ];
+          buildInputs = [
+            pkgs.openssl
+          ];
+        };
+      }
+    )
     // {
       overlays.default = final: prev: {
         inherit (self.packages.${final.system}) lumen;


### PR DESCRIPTION
# Summary

This PR consists of 3 commits:

- **nix: format flake with `nixfmt`**
- **nix: stop using `fenix`**
- **nix: update flake inputs**

The main change is the 2nd one, which replaces the `fenix` toolchain with the stable cargo, rustc, clippy, rustfmt, and
rust-analyzer packages provided by `nixpkgs`.

Lumen only uses stable Rust, so `fenix` adds an unnecessary flake input and makes development shell setup considerably
slower. It is more useful when a project needs nightly Rust or a toolchain version that differs from the one provided by
its pinned `nixpkgs` revision; Lumen currently needs neither.
