### PR TITLE
feat(diff): persist review annotations between sessions

### DIFF
--- a/src/command/diff/annotation_store.rs
+++ b/src/command/diff/annotation_store.rs
@@ -1,0 +1,413 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use super::state::{Annotation, AnnotationTarget};
+use super::types::DiffPanelFocus;
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct AnnotationStore {
+    #[serde(default)]
+    pub schema: u32,
+    #[serde(default)]
+    pub next_id: u64,
+    #[serde(default)]
+    pub annotations: Vec<StoredAnnotation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredAnnotation {
+    pub id: u64,
+    pub filename: String,
+    pub target: StoredTarget,
+    pub content: String,
+    pub created_at_unix: u64,
+    pub anchor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StoredTarget {
+    File,
+    LineRange {
+        panel: StoredPanel,
+        start_line: usize,
+        end_line: usize,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StoredPanel {
+    None,
+    Old,
+    New,
+}
+
+fn panel_to_stored(panel: DiffPanelFocus) -> StoredPanel {
+    match panel {
+        DiffPanelFocus::None => StoredPanel::None,
+        DiffPanelFocus::Old => StoredPanel::Old,
+        DiffPanelFocus::New => StoredPanel::New,
+    }
+}
+
+fn panel_from_stored(panel: &StoredPanel) -> DiffPanelFocus {
+    match panel {
+        StoredPanel::None => DiffPanelFocus::None,
+        StoredPanel::Old => DiffPanelFocus::Old,
+        StoredPanel::New => DiffPanelFocus::New,
+    }
+}
+
+fn target_to_stored(target: &AnnotationTarget) -> StoredTarget {
+    match target {
+        AnnotationTarget::File => StoredTarget::File,
+        AnnotationTarget::LineRange {
+            panel,
+            start_line,
+            end_line,
+        } => StoredTarget::LineRange {
+            panel: panel_to_stored(*panel),
+            start_line: *start_line,
+            end_line: *end_line,
+        },
+    }
+}
+
+fn target_from_stored(target: &StoredTarget) -> AnnotationTarget {
+    match target {
+        StoredTarget::File => AnnotationTarget::File,
+        StoredTarget::LineRange {
+            panel,
+            start_line,
+            end_line,
+        } => AnnotationTarget::LineRange {
+            panel: panel_from_stored(panel),
+            start_line: *start_line,
+            end_line: *end_line,
+        },
+    }
+}
+
+/// Convert a live `Annotation` into its on-disk representation.
+pub fn to_stored(ann: &Annotation) -> StoredAnnotation {
+    let created_at_unix = ann
+        .created_at
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    StoredAnnotation {
+        id: ann.id,
+        filename: ann.filename.clone(),
+        target: target_to_stored(&ann.target),
+        content: ann.content.clone(),
+        created_at_unix,
+        anchor: ann.anchor.clone(),
+    }
+}
+
+/// Convert a stored annotation back into a live `Annotation`.
+///
+/// `stale` is always initialized to `false` here — the caller recomputes
+/// staleness by comparing `anchor` against the current on-disk blob hash.
+pub fn from_stored(stored: &StoredAnnotation) -> Annotation {
+    Annotation {
+        id: stored.id,
+        filename: stored.filename.clone(),
+        target: target_from_stored(&stored.target),
+        content: stored.content.clone(),
+        created_at: UNIX_EPOCH + Duration::from_secs(stored.created_at_unix),
+        anchor: stored.anchor.clone(),
+        stale: false,
+    }
+}
+
+/// Pure path resolution — no I/O, no git shelling, easy to unit test.
+/// `owner_repo` is e.g. "owner/repo" from `resolve_origin_repo()`, or `None` if unresolvable.
+/// `fallback_slug` is used instead when `owner_repo` is `None` (e.g. a slugified cwd path).
+/// `pr_number` takes priority as the session key when present (PR review resumes by PR, not branch,
+/// since branches get force-pushed). Otherwise the session key is a sanitized `diff_reference`,
+/// falling back to `current_branch`. If neither `pr_number`, `diff_reference`, nor `current_branch`
+/// is available, returns `None` (persistence disabled for this session).
+pub fn resolve_annotation_store_path(
+    owner_repo: Option<&str>,
+    fallback_slug: &str,
+    pr_number: Option<u64>,
+    diff_reference: Option<&str>,
+    current_branch: Option<&str>,
+) -> Option<PathBuf> {
+    let state_base = state_base_dir()?;
+    let repo_segment = owner_repo
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("local__{}", fallback_slug));
+    let session_key = if let Some(n) = pr_number {
+        format!("pr-{}", n)
+    } else if let Some(r) = diff_reference {
+        sanitize_key(r)
+    } else if let Some(b) = current_branch {
+        sanitize_key(b)
+    } else {
+        return None;
+    };
+    Some(
+        state_base
+            .join("lumen")
+            .join("annotations")
+            .join(repo_segment)
+            .join(format!("{}.json", session_key)),
+    )
+}
+
+fn state_base_dir() -> Option<PathBuf> {
+    if let Ok(v) = std::env::var("XDG_STATE_HOME") {
+        if !v.is_empty() {
+            return Some(PathBuf::from(v));
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".local").join("state"))
+}
+
+fn sanitize_key(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .to_lowercase()
+}
+
+/// Slugify an arbitrary path for the `local__<slug>` fallback repo segment.
+pub fn slugify_path(path: &Path) -> String {
+    sanitize_key(&path.to_string_lossy())
+}
+
+pub fn load(path: &Path) -> AnnotationStore {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return AnnotationStore::default();
+    };
+    match serde_json::from_str::<AnnotationStore>(&contents) {
+        Ok(store) if store.schema == SCHEMA_VERSION => store,
+        _ => AnnotationStore::default(),
+    }
+}
+
+pub fn save_merged(path: &Path, update: impl FnOnce(&mut AnnotationStore)) -> io::Result<()> {
+    let mut store = load(path);
+    store.schema = SCHEMA_VERSION;
+    update(&mut store);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if store.annotations.is_empty() {
+        let _ = fs::remove_file(path);
+        return Ok(());
+    }
+    let json = serde_json::to_string_pretty(&store).unwrap_or_default();
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, json)?;
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+/// git2::Oid::hash_object over the working-tree file's current bytes on disk.
+/// Returns `None` on any I/O or git2 error — never panics.
+pub fn blob_hash_for_path(filename: &str) -> Option<String> {
+    let bytes = fs::read(filename).ok()?;
+    git2::Oid::hash_object(git2::ObjectType::Blob, &bytes)
+        .ok()
+        .map(|oid| oid.to_string())
+}
+
+/// Best-effort deletion of `*.json` files under `repo_dir` whose mtime is older
+/// than `max_age_days`. Swallows every error — must never fail the caller.
+pub fn prune_stale(repo_dir: &Path, max_age_days: u64) {
+    let Ok(entries) = fs::read_dir(repo_dir) else {
+        return;
+    };
+    let cutoff = SystemTime::now().checked_sub(Duration::from_secs(max_age_days * 86_400));
+    let Some(cutoff) = cutoff else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = fs::remove_file(&path);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("lumen-annotation-store-test-{}", name));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn resolve_path_prefers_pr_number_over_other_args() {
+        let path = resolve_annotation_store_path(
+            Some("owner/repo"),
+            "fallback",
+            Some(42),
+            Some("main..feature"),
+            Some("feature"),
+        )
+        .unwrap();
+
+        assert_eq!(path.file_name().unwrap(), "pr-42.json");
+    }
+
+    #[test]
+    fn resolve_path_uses_diff_reference_when_no_pr() {
+        let path = resolve_annotation_store_path(
+            Some("owner/repo"),
+            "fallback",
+            None,
+            Some("main..feature"),
+            Some("feature"),
+        )
+        .unwrap();
+
+        assert_eq!(path.file_name().unwrap(), "main--feature.json");
+    }
+
+    #[test]
+    fn resolve_path_uses_current_branch_when_no_pr_or_reference() {
+        let path = resolve_annotation_store_path(
+            Some("owner/repo"),
+            "fallback",
+            None,
+            None,
+            Some("my-feature"),
+        )
+        .unwrap();
+
+        assert_eq!(path.file_name().unwrap(), "my-feature.json");
+    }
+
+    #[test]
+    fn resolve_path_returns_none_when_no_session_key_available() {
+        let path = resolve_annotation_store_path(Some("owner/repo"), "fallback", None, None, None);
+
+        assert!(path.is_none());
+    }
+
+    #[test]
+    fn resolve_path_falls_back_to_local_slug_when_owner_repo_unresolved() {
+        let path =
+            resolve_annotation_store_path(None, "my-slug", None, None, Some("main")).unwrap();
+
+        assert!(path.to_string_lossy().contains("local__my-slug"));
+    }
+
+    #[test]
+    fn load_returns_default_store_when_file_missing() {
+        let dir = temp_dir("load-missing");
+        let path = dir.join("does-not-exist.json");
+
+        let store = load(&path);
+
+        assert_eq!(store.schema, 0);
+        assert!(store.annotations.is_empty());
+    }
+
+    #[test]
+    fn load_returns_default_store_when_schema_mismatched() {
+        let dir = temp_dir("load-schema-mismatch");
+        let path = dir.join("annotations.json");
+        fs::write(&path, r#"{"schema":999,"next_id":5,"annotations":[]}"#).unwrap();
+
+        let store = load(&path);
+
+        assert_eq!(store.schema, 0);
+        assert_eq!(store.next_id, 0);
+    }
+
+    #[test]
+    fn save_merged_round_trips_annotations() {
+        let dir = temp_dir("save-round-trip");
+        let path = dir.join("annotations.json");
+
+        save_merged(&path, |store| {
+            store.next_id = 3;
+            store.annotations.push(StoredAnnotation {
+                id: 1,
+                filename: "src/main.rs".to_string(),
+                target: StoredTarget::File,
+                content: "looks good".to_string(),
+                created_at_unix: 1000,
+                anchor: Some("deadbeef".to_string()),
+            });
+        })
+        .unwrap();
+
+        let loaded = load(&path);
+        assert_eq!(loaded.next_id, 3);
+        assert_eq!(loaded.annotations.len(), 1);
+        assert_eq!(loaded.annotations[0].filename, "src/main.rs");
+        assert_eq!(loaded.annotations[0].content, "looks good");
+    }
+
+    #[test]
+    fn save_merged_deletes_file_when_store_ends_up_empty() {
+        let dir = temp_dir("save-empty-deletes");
+        let path = dir.join("annotations.json");
+
+        save_merged(&path, |store| {
+            store.annotations.push(StoredAnnotation {
+                id: 1,
+                filename: "a.rs".to_string(),
+                target: StoredTarget::File,
+                content: "note".to_string(),
+                created_at_unix: 1,
+                anchor: None,
+            });
+        })
+        .unwrap();
+        assert!(path.exists());
+
+        save_merged(&path, |store| {
+            store.annotations.clear();
+        })
+        .unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn save_merged_leaves_no_leftover_tmp_file() {
+        let dir = temp_dir("save-no-tmp-leftover");
+        let path = dir.join("annotations.json");
+
+        save_merged(&path, |store| {
+            store.annotations.push(StoredAnnotation {
+                id: 1,
+                filename: "a.rs".to_string(),
+                target: StoredTarget::File,
+                content: "note".to_string(),
+                created_at_unix: 1,
+                anchor: None,
+            });
+        })
+        .unwrap();
+
+        let tmp_path = path.with_extension("json.tmp");
+        assert!(!tmp_path.exists());
+    }
+}

--- a/src/command/diff/app.rs
+++ b/src/command/diff/app.rs
@@ -36,6 +36,7 @@ fn open_tui_writer() -> io::Result<Box<dyn Write + Send>> {
 }
 
 use super::annotation::{AnnotationEditor, AnnotationEditorResult};
+use super::annotation_store;
 use super::coordinates::{extract_selected_text, PanelLayout};
 use super::git::{
     get_current_branch, load_file_diffs, load_pr_file_diffs, load_single_commit_diffs,
@@ -230,22 +231,25 @@ fn format_annotation_preview(annotation: &super::state::Annotation) -> String {
     let truncated_filename = truncate_path(&annotation.filename, 30);
     let line_display = annotation.line_range_display();
     let label = annotation.target_label();
+    let stale_marker = if annotation.stale { " (stale)" } else { "" };
     if line_display.is_empty() {
         format!(
-            "{} [{}] | {} | {}",
+            "{} [{}] | {} | {}{}",
             truncated_filename,
             label,
             preview,
-            annotation.format_time()
+            annotation.format_time(),
+            stale_marker
         )
     } else {
         format!(
-            "{}:{} [{}] | {} | {}",
+            "{}:{} [{}] | {} | {}{}",
             truncated_filename,
             line_display,
             label,
             preview,
-            annotation.format_time()
+            annotation.format_time(),
+            stale_marker
         )
     }
 }
@@ -293,6 +297,63 @@ fn sync_viewed_files_from_github(pr_info: &PrInfo, state: &mut AppState) {
     }
 }
 
+/// Resolve where (if anywhere) this session's annotations should be persisted.
+/// Returns `None` when persistence is disabled via `--no-save-annotations` or
+/// when no stable session key (PR number, diff reference, or branch) exists.
+fn init_annotation_persistence(
+    options: &DiffOptions,
+    pr_info: Option<&PrInfo>,
+    diff_reference: Option<&str>,
+    backend: &dyn VcsBackend,
+) -> Option<std::path::PathBuf> {
+    if !options.save_annotations {
+        return None;
+    }
+    let owner_repo = super::resolve_origin_repo().ok();
+    let fallback_slug = std::env::current_dir()
+        .map(|p| annotation_store::slugify_path(&p))
+        .unwrap_or_else(|_| "unknown".to_string());
+    let pr_number = pr_info.map(|p| p.number);
+    let current_branch = backend.get_current_branch().ok().flatten();
+    annotation_store::resolve_annotation_store_path(
+        owner_repo.as_deref(),
+        &fallback_slug,
+        pr_number,
+        diff_reference,
+        current_branch.as_deref(),
+    )
+}
+
+/// Load previously saved annotations for this session into `state`,
+/// marking any whose blob hash no longer matches the file on disk as stale.
+fn apply_saved_annotations(state: &mut AppState, path: &std::path::Path) {
+    let store = annotation_store::load(path);
+    let mut max_id = store.next_id;
+    for stored in &store.annotations {
+        let mut ann = annotation_store::from_stored(stored);
+        let current_hash = annotation_store::blob_hash_for_path(&ann.filename);
+        ann.stale = ann.anchor.is_some() && ann.anchor != current_hash;
+        if ann.id >= max_id {
+            max_id = ann.id + 1;
+        }
+        state.annotations.push(ann);
+    }
+    state.set_annotation_next_id_floor(max_id);
+}
+
+/// Write the current annotation set to disk, if persistence is enabled for this session.
+fn persist_annotations(state: &AppState, path: &Option<std::path::PathBuf>) {
+    let Some(path) = path else { return };
+    let _ = annotation_store::save_merged(path, |store| {
+        store.annotations = state
+            .annotations
+            .iter()
+            .map(annotation_store::to_stored)
+            .collect();
+        store.next_id = state.annotation_next_id();
+    });
+}
+
 fn run_app_internal(
     options: DiffOptions,
     pr_info: Option<PrInfo>,
@@ -322,7 +383,7 @@ fn run_app_internal(
             CommitReference::RangeToWorkingTree { from } => format!("{}..-", from),
         })
     };
-    state.set_diff_reference(diff_ref_str);
+    state.set_diff_reference(diff_ref_str.clone());
 
     // Initialize stacked mode if commits were provided
     if let Some(commits) = stacked_commits {
@@ -339,6 +400,22 @@ fn run_app_internal(
         sync_viewed_files_from_github(pr, &mut state);
         let viewed_count = state.viewed_files.len();
         spinner.success(&format!("{} files marked as viewed", viewed_count));
+    }
+
+    let annotation_store_path =
+        init_annotation_persistence(&options, pr_info.as_ref(), diff_ref_str.as_deref(), backend);
+    if let Some(ref path) = annotation_store_path {
+        if let Some(parent) = path.parent() {
+            annotation_store::prune_stale(parent, 30);
+        }
+        apply_saved_annotations(&mut state, path);
+        let stale_count = state.annotations.iter().filter(|a| a.stale).count();
+        if stale_count > 0 {
+            eprintln!(
+                "{} annotation(s) may be stale — file changed since they were written",
+                stale_count
+            );
+        }
     }
 
     // Now enter TUI mode. Use /dev/tty when stdout is captured so the
@@ -439,7 +516,8 @@ fn run_app_internal(
             let row_offset = std::cell::Cell::new(0usize);
             let gaps_cell = std::cell::RefCell::new(Vec::new());
             let rects_cell = std::cell::RefCell::new(Vec::new());
-            let editor_rect_cell: std::cell::Cell<Option<ratatui::layout::Rect>> = std::cell::Cell::new(None);
+            let editor_rect_cell: std::cell::Cell<Option<ratatui::layout::Rect>> =
+                std::cell::Cell::new(None);
             terminal.draw(|frame| {
                 let (offset, gaps, rects, er) = render_diff(
                     frame,
@@ -658,6 +736,7 @@ fn run_app_internal(
                                 if let Some(id) = editor.id {
                                     // Editing existing annotation
                                     state.update_annotation(id, content);
+                                    persist_annotations(&state, &annotation_store_path);
                                 } else {
                                     // New annotation
                                     state.add_annotation(
@@ -665,13 +744,16 @@ fn run_app_internal(
                                         editor.target.clone(),
                                         content,
                                         editor.created_at(),
+                                        annotation_store::blob_hash_for_path(&editor.filename),
                                     );
+                                    persist_annotations(&state, &annotation_store_path);
                                 }
                                 annotation_editor = None;
                             }
                             AnnotationEditorResult::Delete => {
                                 if let Some(id) = editor.id {
                                     state.remove_annotation(id);
+                                    persist_annotations(&state, &annotation_store_path);
                                 }
                                 annotation_editor = None;
                             }
@@ -759,6 +841,7 @@ fn run_app_internal(
                                 }
                                 ModalResult::AnnotationDelete { annotation_id } => {
                                     state.remove_annotation(annotation_id);
+                                    persist_annotations(&state, &annotation_store_path);
                                     // Refresh the modal if there are still annotations
                                     if !state.annotations.is_empty() {
                                         let mut sorted_annotations = state.annotations.clone();
@@ -901,18 +984,24 @@ fn run_app_internal(
                                         if editor.is_empty() {
                                             if let Some(id) = editor.id {
                                                 state.remove_annotation(id);
+                                                persist_annotations(&state, &annotation_store_path);
                                             }
                                         } else {
                                             let content = editor.content();
                                             if let Some(id) = editor.id {
                                                 state.update_annotation(id, content);
+                                                persist_annotations(&state, &annotation_store_path);
                                             } else {
                                                 state.add_annotation(
                                                     editor.filename.clone(),
                                                     editor.target.clone(),
                                                     content,
                                                     editor.created_at(),
+                                                    annotation_store::blob_hash_for_path(
+                                                        &editor.filename,
+                                                    ),
                                                 );
+                                                persist_annotations(&state, &annotation_store_path);
                                             }
                                         }
                                     }
@@ -1900,10 +1989,8 @@ fn run_app_internal(
                         }
                         KeyCode::Char('e') => {
                             if !state.file_diffs.is_empty() {
-                                let _ = execute!(
-                                    terminal.backend_mut(),
-                                    PopKeyboardEnhancementFlags
-                                );
+                                let _ =
+                                    execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
                                 execute!(
                                     terminal.backend_mut(),
                                     DisableMouseCapture,
@@ -1952,7 +2039,9 @@ fn run_app_internal(
                                 )?;
                                 let _ = execute!(
                                     terminal.backend_mut(),
-                                    PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+                                    PushKeyboardEnhancementFlags(
+                                        KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                                    )
                                 );
                                 terminal.clear()?;
                             }
@@ -2106,10 +2195,10 @@ fn run_app_internal(
                                                 key: "h/l or left/right",
                                                 description: "Scroll horizontally",
                                             },
-                                        KeyBind {
-                                            key: "w",
-                                            description: "Toggle watch mode",
-                                        },
+                                            KeyBind {
+                                                key: "w",
+                                                description: "Toggle watch mode",
+                                            },
                                             KeyBind {
                                                 key: "gg / G",
                                                 description: "Scroll to top / bottom",
@@ -2153,7 +2242,8 @@ fn run_app_internal(
                                             },
                                             KeyBind {
                                                 key: "ctrl+f",
-                                                description: "Global fuzzy search (all files, with preview)",
+                                                description:
+                                                    "Global fuzzy search (all files, with preview)",
                                             },
                                             KeyBind {
                                                 key: "n or down",

--- a/src/command/diff/git.rs
+++ b/src/command/diff/git.rs
@@ -155,8 +155,7 @@ pub fn load_file_diffs(options: &DiffOptions, backend: &dyn VcsBackend) -> Vec<F
             } else {
                 FileStatus::Modified
             };
-            let is_binary =
-                is_binary_content(&old_content) || is_binary_content(&new_content);
+            let is_binary = is_binary_content(&old_content) || is_binary_content(&new_content);
             FileDiff {
                 filename,
                 old_content,
@@ -244,8 +243,7 @@ pub fn load_pr_file_diffs(pr_info: &PrInfo) -> Result<Vec<FileDiff>, String> {
                 FileStatus::Modified
             };
 
-            let is_binary =
-                is_binary_content(&old_content) || is_binary_content(&new_content);
+            let is_binary = is_binary_content(&old_content) || is_binary_content(&new_content);
             FileDiff {
                 filename,
                 old_content,
@@ -481,8 +479,7 @@ pub fn load_single_commit_diffs(
                 FileStatus::Modified
             };
 
-            let is_binary =
-                is_binary_content(&old_content) || is_binary_content(&new_content);
+            let is_binary = is_binary_content(&old_content) || is_binary_content(&new_content);
             FileDiff {
                 filename,
                 old_content,
@@ -537,6 +534,7 @@ mod tests {
             focus: None,
             origin: None,
             wrap: false,
+            save_annotations: false,
         };
 
         let diffs = load_file_diffs(&options, &backend);
@@ -609,6 +607,7 @@ mod tests {
             focus: None,
             origin: None,
             wrap: false,
+            save_annotations: false,
         };
 
         let diffs = load_file_diffs(&options, &backend);

--- a/src/command/diff/mod.rs
+++ b/src/command/diff/mod.rs
@@ -1,4 +1,5 @@
 mod annotation;
+mod annotation_store;
 mod app;
 mod context;
 mod coordinates;
@@ -36,6 +37,7 @@ pub struct DiffOptions {
     pub focus: Option<String>,
     pub origin: Option<String>,
     pub wrap: bool,
+    pub save_annotations: bool,
 }
 
 #[derive(Clone)]
@@ -78,7 +80,7 @@ fn parse_pr_input(input: &str) -> Option<(Option<String>, Option<String>, u64)> 
     }
 }
 
-fn resolve_origin_repo() -> Result<String, String> {
+pub(crate) fn resolve_origin_repo() -> Result<String, String> {
     let output = Command::new("git")
         .args(["remote", "get-url", "origin"])
         .output()

--- a/src/command/diff/state.rs
+++ b/src/command/diff/state.rs
@@ -4,13 +4,15 @@ use std::time::SystemTime;
 use tree_sitter::{Parser, Tree};
 
 use crate::command::diff::context::get_language_context;
-use crate::command::diff::diff_algo::{compute_side_by_side, count_added_removed, find_hunk_starts};
+use crate::command::diff::diff_algo::{
+    compute_side_by_side, count_added_removed, find_hunk_starts,
+};
 use crate::command::diff::highlight::FileHighlighter;
 
 use crate::command::diff::search::SearchState;
 use crate::command::diff::types::{
-    build_file_tree, CursorPosition, DiffFullscreen, DiffLine, DiffPanelFocus,
-    DiffViewSettings, FileDiff, FocusedPanel, Selection, SelectionMode, SidebarItem,
+    build_file_tree, CursorPosition, DiffFullscreen, DiffLine, DiffPanelFocus, DiffViewSettings,
+    FileDiff, FocusedPanel, Selection, SelectionMode, SidebarItem,
 };
 use crate::vcs::StackedCommitInfo;
 
@@ -93,6 +95,8 @@ pub struct Annotation {
     pub target: AnnotationTarget,
     pub content: String,
     pub created_at: SystemTime,
+    pub anchor: Option<String>,
+    pub stale: bool,
 }
 
 impl Annotation {
@@ -108,7 +112,10 @@ impl Annotation {
     #[cfg(not(feature = "jj"))]
     pub fn format_time(&self) -> String {
         use std::time::UNIX_EPOCH;
-        let duration = self.created_at.duration_since(UNIX_EPOCH).unwrap_or_default();
+        let duration = self
+            .created_at
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
         let secs = duration.as_secs();
         let hours = (secs / 3600) % 24;
         let minutes = (secs / 60) % 60;
@@ -131,7 +138,11 @@ impl Annotation {
     pub fn line_range_display(&self) -> String {
         match &self.target {
             AnnotationTarget::File => String::new(),
-            AnnotationTarget::LineRange { start_line, end_line, .. } => {
+            AnnotationTarget::LineRange {
+                start_line,
+                end_line,
+                ..
+            } => {
                 if start_line == end_line {
                     format!("L{}", start_line)
                 } else {
@@ -575,7 +586,12 @@ impl AppState {
     }
 
     /// Start a new selection
-    pub fn start_selection(&mut self, panel: DiffPanelFocus, pos: CursorPosition, mode: SelectionMode) {
+    pub fn start_selection(
+        &mut self,
+        panel: DiffPanelFocus,
+        pos: CursorPosition,
+        mode: SelectionMode,
+    ) {
         self.diff_panel_focus = panel;
         self.selection = Selection {
             panel,
@@ -799,6 +815,11 @@ impl AppState {
                 viewed_filenames.remove(filename);
                 self.viewed_hunks.remove(filename);
             }
+            for ann in self.annotations.iter_mut() {
+                if changed.contains(&ann.filename) {
+                    ann.stale = true;
+                }
+            }
         }
 
         self.file_diffs = file_diffs;
@@ -808,9 +829,15 @@ impl AppState {
         self.sidebar_items = build_file_tree(&self.file_diffs);
 
         // Retain annotations whose file still exists
-        let filenames: HashSet<&str> = self.file_diffs.iter().map(|f| f.filename.as_str()).collect();
-        self.annotations.retain(|ann| filenames.contains(ann.filename.as_str()));
-        self.viewed_hunks.retain(|fname, _| filenames.contains(fname.as_str()));
+        let filenames: HashSet<&str> = self
+            .file_diffs
+            .iter()
+            .map(|f| f.filename.as_str())
+            .collect();
+        self.annotations
+            .retain(|ann| filenames.contains(ann.filename.as_str()));
+        self.viewed_hunks
+            .retain(|fname, _| filenames.contains(fname.as_str()));
 
         // Convert viewed filenames back to indices in the new file_diffs
         self.viewed_files = self
@@ -879,7 +906,14 @@ impl AppState {
     }
 
     /// Add a new annotation, returns its id
-    pub fn add_annotation(&mut self, filename: String, target: AnnotationTarget, content: String, created_at: SystemTime) -> u64 {
+    pub fn add_annotation(
+        &mut self,
+        filename: String,
+        target: AnnotationTarget,
+        content: String,
+        created_at: SystemTime,
+        anchor: Option<String>,
+    ) -> u64 {
         let id = self.annotation_next_id;
         self.annotation_next_id += 1;
         self.annotations.push(Annotation {
@@ -888,8 +922,23 @@ impl AppState {
             target,
             content,
             created_at,
+            anchor,
+            stale: false,
         });
         id
+    }
+
+    /// Get the next annotation id that will be assigned
+    pub fn annotation_next_id(&self) -> u64 {
+        self.annotation_next_id
+    }
+
+    /// Raise the next annotation id counter to at least `floor`, so ids
+    /// restored from disk never collide with newly created ones.
+    pub fn set_annotation_next_id_floor(&mut self, floor: u64) {
+        if floor > self.annotation_next_id {
+            self.annotation_next_id = floor;
+        }
     }
 
     /// Update an existing annotation's content
@@ -925,7 +974,12 @@ impl AppState {
                 AnnotationTarget::File => {
                     result.push_str(&format!("**{}**\n\n", ann.filename));
                 }
-                AnnotationTarget::LineRange { panel, start_line, end_line, .. } => {
+                AnnotationTarget::LineRange {
+                    panel,
+                    start_line,
+                    end_line,
+                    ..
+                } => {
                     let side = match panel {
                         DiffPanelFocus::Old => "LEFT",
                         _ => "RIGHT",
@@ -1062,7 +1116,9 @@ mod tests {
 
         let state = AppState::new(diffs, Some("ccc.rs"));
 
-        if let Some(SidebarItem::File { file_index, .. }) = state.sidebar_item_at_visible(state.sidebar_selected) {
+        if let Some(SidebarItem::File { file_index, .. }) =
+            state.sidebar_item_at_visible(state.sidebar_selected)
+        {
             assert_eq!(*file_index, state.current_file);
         } else {
             panic!("sidebar_selected should point to a file");

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -147,6 +147,10 @@ pub enum Commands {
         /// Soft-wrap long diff lines instead of scrolling horizontally
         #[arg(long)]
         wrap: bool,
+
+        /// Disable persisting review annotations to disk between sessions
+        #[arg(long = "no-save-annotations")]
+        no_save_annotations: bool,
     },
     /// Interactively configure Lumen (provider, API key)
     Configure,

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -32,6 +32,9 @@ pub struct LumenConfig {
 
     #[serde(default)]
     pub wrap: Option<bool>,
+
+    #[serde(default)]
+    pub save_annotations: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -130,6 +133,7 @@ impl LumenConfig {
             draft: config.draft,
             theme: config.theme,
             wrap: config.wrap,
+            save_annotations: config.save_annotations,
         })
     }
 
@@ -156,6 +160,7 @@ impl Default for LumenConfig {
             draft: default_draft_config(),
             theme: None,
             wrap: None,
+            save_annotations: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,7 @@ async fn run() -> Result<(), LumenError> {
             focus,
             origin,
             wrap,
+            no_save_annotations,
         } => {
             let options = command::diff::DiffOptions {
                 reference,
@@ -145,6 +146,7 @@ async fn run() -> Result<(), LumenError> {
                 focus,
                 origin,
                 wrap: wrap || config.wrap.unwrap_or(false),
+                save_annotations: !no_save_annotations && config.save_annotations.unwrap_or(true),
             };
             command::diff::run_diff_ui(options, backend.as_ref())?;
         }


### PR DESCRIPTION
Persists review annotations to local disk (`$XDG_STATE_HOME`/`~/.local/state`/lumen/annotations/...) so they survive crashes and accidental quits, keyed by PR number/diff-reference/branch, with staleness detection when the underlying file changes. Enabled by default; opt out with `--no-save-annotations`.

Resolves #135