### PR TITLE
fix: use actual buffer rows instead of visual lines for sticky scroll

### DIFF
--- a/src/command/diff/render/diff_view.rs
+++ b/src/command/diff/render/diff_view.rs
@@ -1781,11 +1781,24 @@ pub fn render_diff(
             }
         };
 
+        let old_scroll = side_by_side
+            .iter()
+            .skip(scroll as usize)
+            .find_map(|dl| dl.old_line.as_ref().map(|(n, _)| *n))
+            .map(|n| n.saturating_sub(1))
+            .unwrap_or_else(|| diff.old_content.lines().count());
+        let new_scroll = side_by_side
+            .iter()
+            .skip(scroll as usize)
+            .find_map(|dl| dl.new_line.as_ref().map(|(n, _)| *n))
+            .map(|n| n.saturating_sub(1))
+            .unwrap_or_else(|| diff.new_content.lines().count());
+        
         let old_context = compute_context_lines(
             &diff.old_content,
             &diff.filename,
             &trees.old_file_trees,
-            scroll as usize,
+            old_scroll,
             &settings.context,
             settings.tab_width,
         );
@@ -1793,7 +1806,7 @@ pub fn render_diff(
             &diff.new_content,
             &diff.filename,
             &trees.new_file_trees,
-            scroll as usize,
+            new_scroll,
             &settings.context,
             settings.tab_width,
         );


### PR DESCRIPTION
In the "New" file view, adding a new line causes the sticky context to start one line before the actual struct definition:

<img width="1493" height="676" alt="lumen-before-1" src="https://github.com/user-attachments/assets/75f80614-a589-48aa-a96a-491440ed7c7e" />

and end one line early:

<img width="1493" height="371" alt="lumen-before-2" src="https://github.com/user-attachments/assets/1ae2120c-458e-4dfa-8d08-d2c4ebae967f" />

This off-by-one issue gets significantly worse the more differences there are between the two files.

## After the change

<img width="1496" height="656" alt="lumen-after-1" src="https://github.com/user-attachments/assets/b9606e84-fc64-43e0-bdaf-57cf4005c511" />
<img width="1506" height="323" alt="lumen-after-2" src="https://github.com/user-attachments/assets/f6f148cc-efff-4254-b367-c6601d1ad645" />