### PR TITLE
feat(highlight): Swift syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,6 +2600,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
  "tree-sitter-zig",
@@ -2921,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4405,6 +4406,16 @@ name = "tree-sitter-rust"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc72ea9c62a6d188c9f7d64109a9b14b09231852b87229c68c44e8738b9e6b9"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tree-sitter-java = "0.23"
 tree-sitter-zig = "1.1.2"
 tree-sitter-c = "0.23"
 tree-sitter-cpp = "0.23"
+tree-sitter-swift = "=0.7.0"
 once_cell = "1.20"
 arboard = { version = "3.4", features = ["wayland-data-control"] }
 nucleo-matcher = "0.3"

--- a/src/command/diff/highlight/config.rs
+++ b/src/command/diff/highlight/config.rs
@@ -297,5 +297,13 @@ pub static CONFIGS: Lazy<Vec<(&'static str, LanguageConfig)>> = Lazy::new(|| {
         &mut configs,
     );
 
+    load_config(
+        tree_sitter_swift::LANGUAGE.into(),
+        "swift",
+        SWIFT_HIGHLIGHTS,
+        "swift",
+        &mut configs,
+    );
+
     configs
 });

--- a/src/command/diff/highlight/mod.rs
+++ b/src/command/diff/highlight/mod.rs
@@ -248,6 +248,7 @@ mod tests {
         assert!(extensions.contains(&"hpp"), "C++ .hpp config should be loaded");
         assert!(extensions.contains(&"hh"), "C++ .hh config should be loaded");
         assert!(extensions.contains(&"hxx"), "C++ .hxx config should be loaded");
+        assert!(extensions.contains(&"swift"), "Swift config should be loaded");
     }
 
     #[test]
@@ -451,6 +452,139 @@ int main() {
         assert!(
             has_namespace_keyword,
             "C++ 'namespace' should be highlighted as keyword"
+        );
+    }
+
+    #[test]
+    fn test_swift_highlighting() {
+        use config::HIGHLIGHT_NAMES;
+        let code = r#"import Foundation
+
+// A greeting service
+public protocol Greeter {
+    var name: String { get }
+    func greet() -> String
+}
+
+public struct Person: Greeter {
+    public var name: String
+    private var age: Int
+
+    public init(name: String, age: Int) {
+        self.name = name
+        self.age = age
+    }
+
+    public func greet() -> String {
+        let message = "Hello, \\(self.name)!"
+        return message
+    }
+}
+
+let greeting = Person(name: "Jane", age: 30).greet()
+"#;
+        let result = highlight_code(code, "test.swift");
+        assert!(
+            !result.is_empty(),
+            "Swift highlighting should produce output"
+        );
+        let has_highlights = result.iter().any(|(_, h)| h.is_some());
+        assert!(
+            has_highlights,
+            "Swift code should have syntax highlights"
+        );
+
+        let idx = |name: &str| {
+            HIGHLIGHT_NAMES
+                .iter()
+                .position(|&n| n == name)
+                .unwrap_or_else(|| panic!("{} should be a valid highlight name", name))
+        };
+        let comment_idx = Some(idx("comment"));
+        let keyword_idx = Some(idx("keyword"));
+        let type_idx = Some(idx("type"));
+        let function_idx = Some(idx("function"));
+        let method_idx = Some(idx("function.method"));
+        let string_idx = Some(idx("string"));
+        let number_idx = Some(idx("number"));
+        let constructor_idx = Some(idx("constructor"));
+        let param_idx = Some(idx("variable.parameter"));
+        let builtin_idx = Some(idx("variable.builtin"));
+        let member_idx = Some(idx("variable.member"));
+
+        // Comments
+        assert!(
+            result.iter().any(|(t, h)| t.contains("A greeting service") && *h == comment_idx),
+            "Swift comment should be highlighted as 'comment'"
+        );
+
+        // Keywords
+        for kw in ["import", "protocol", "struct", "func", "var", "let", "return", "public"] {
+            assert!(
+                result.iter().any(|(t, h)| t == kw && *h == keyword_idx),
+                "Swift keyword '{}' should be highlighted as 'keyword'",
+                kw
+            );
+        }
+
+        // Types
+        assert!(
+            result.iter().any(|(t, h)| t == "Greeter" && *h == type_idx),
+            "Protocol name should be highlighted as 'type'"
+        );
+        assert!(
+            result.iter().any(|(t, h)| t == "Person" && *h == type_idx),
+            "Struct name should be highlighted as 'type'"
+        );
+        assert!(
+            result.iter().any(|(t, h)| t == "String" && *h == type_idx),
+            "'String' should be highlighted as 'type'"
+        );
+
+        // Function declarations vs. method calls (tie-break: calls win)
+        assert!(
+            result.iter().any(|(t, h)| t == "greet" && *h == function_idx),
+            "Declared function 'greet' should be highlighted as 'function'"
+        );
+        assert!(
+            result.iter().any(|(t, h)| t == "greet" && *h == method_idx),
+            "Called method 'greet' should be highlighted as 'function.method'"
+        );
+        assert!(
+            result.iter().any(|(t, h)| t == "Person" && *h == function_idx),
+            "Constructor call 'Person' should be highlighted as 'function'"
+        );
+
+        // init
+        assert!(
+            result.iter().any(|(t, h)| t == "init" && *h == constructor_idx),
+            "'init' should be highlighted as 'constructor'"
+        );
+
+        // Parameters
+        assert!(
+            result.iter().any(|(t, h)| t == "age" && *h == param_idx),
+            "Parameter 'age' should be highlighted as 'variable.parameter'"
+        );
+
+        // Self / members
+        assert!(
+            result.iter().any(|(t, h)| t == "self" && *h == builtin_idx),
+            "'self' should be highlighted as 'variable.builtin'"
+        );
+        assert!(
+            result.iter().any(|(t, h)| t == "name" && *h == member_idx),
+            "Member 'name' in 'self.name' should be highlighted as 'variable.member'"
+        );
+
+        // Strings and numbers
+        assert!(
+            result.iter().any(|(t, h)| t.contains("Jane") && *h == string_idx),
+            "String literal should be highlighted as 'string'"
+        );
+        assert!(
+            result.iter().any(|(t, h)| t == "30" && *h == number_idx),
+            "Number literal '30' should be highlighted as 'number'"
         );
     }
 

--- a/src/command/diff/highlight/queries.rs
+++ b/src/command/diff/highlight/queries.rs
@@ -1296,3 +1296,233 @@ pub const CPP_HIGHLIGHTS: &str = r##"
 ";" @punctuation.delimiter
 ":" @punctuation.delimiter
 "##;
+
+pub const SWIFT_HIGHLIGHTS: &str = r#"
+; Comments
+[
+  (comment)
+  (multiline_comment)
+] @comment
+
+; Strings and literals
+(line_str_text) @string
+(multi_line_str_text) @string
+(raw_str_part) @string
+(raw_str_end_part) @string
+(str_escaped_char) @string.special
+[
+  "\""
+  "\"\"\""
+] @string
+(line_string_literal
+  [
+    "\\("
+    ")"
+  ] @punctuation)
+(multi_line_string_literal
+  [
+    "\\("
+    ")"
+  ] @punctuation)
+(raw_str_interpolation
+  [
+    (raw_str_interpolation_start)
+    ")"
+  ] @punctuation)
+(regex_literal) @string.special
+
+; Numbers
+[
+  (integer_literal)
+  (hex_literal)
+  (oct_literal)
+  (bin_literal)
+  (real_literal)
+] @number
+
+; Constants / builtins
+(boolean_literal) @constant.builtin
+"nil" @constant.builtin
+(wildcard_pattern) @constant.builtin
+
+; Types
+(type_identifier) @type
+((navigation_expression
+  (simple_identifier) @type)
+  (#match? @type "^[A-Z]"))
+
+; Members and properties (defined BEFORE call captures so calls win on tie)
+(class_body
+  (property_declaration
+    (pattern
+      (simple_identifier) @variable.member)))
+(protocol_property_declaration
+  (pattern
+    (simple_identifier) @variable.member))
+(navigation_expression
+  (navigation_suffix
+    (simple_identifier) @variable.member))
+
+; Functions
+(function_declaration
+  (simple_identifier) @function)
+(protocol_function_declaration
+  name: (simple_identifier) @function)
+(init_declaration
+  "init" @constructor)
+(call_expression
+  (simple_identifier) @function)
+(call_expression
+  (navigation_expression
+    (navigation_suffix
+      (simple_identifier) @function.method)))
+(call_expression
+  (prefix_expression
+    (simple_identifier) @function.method))
+
+; Parameters
+(parameter
+  external_name: (simple_identifier) @variable.parameter)
+(parameter
+  name: (simple_identifier) @variable.parameter)
+
+; Self / super
+[
+  (self_expression)
+  (super_expression)
+] @variable.builtin
+
+; Attributes
+(modifiers
+  (attribute
+    "@" @attribute
+    (user_type
+      (type_identifier) @attribute)))
+
+; Keywords
+[
+  "func"
+  "deinit"
+  "protocol"
+  "extension"
+  "indirect"
+  "nonisolated"
+  "override"
+  "convenience"
+  "required"
+  "some"
+  "any"
+  "weak"
+  "unowned"
+  "didSet"
+  "willSet"
+  "subscript"
+  "let"
+  "var"
+  "enum"
+  "struct"
+  "class"
+  "typealias"
+  "async"
+  "await"
+  "import"
+  "case"
+  "for"
+  "in"
+  "while"
+  "repeat"
+  "continue"
+  "break"
+  "guard"
+  "if"
+  "switch"
+  "fallthrough"
+  "return"
+  "do"
+  "try"
+] @keyword
+[
+  (visibility_modifier)
+  (member_modifier)
+  (function_modifier)
+  (property_modifier)
+  (parameter_modifier)
+  (inheritance_modifier)
+  (mutation_modifier)
+  (throws)
+  (where_keyword)
+  (getter_specifier)
+  (setter_specifier)
+  (modify_specifier)
+  (try_operator)
+  (throw_keyword)
+  (catch_keyword)
+  (else)
+] @keyword
+(shebang_line) @keyword
+(directive) @keyword
+
+; Operators
+(custom_operator) @operator
+[
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "="
+  "+="
+  "-="
+  "*="
+  "/="
+  "<"
+  ">"
+  "<<"
+  ">>"
+  "<="
+  ">="
+  "++"
+  "--"
+  "^"
+  "&"
+  "&&"
+  "|"
+  "||"
+  "~"
+  "%="
+  "!="
+  "!=="
+  "=="
+  "==="
+  "?"
+  "??"
+  "->"
+  "..<"
+  "..."
+  (bang)
+] @operator
+
+; Labels
+(statement_label) @label
+
+; Punctuation
+[
+  "."
+  ";"
+  ":"
+  ","
+] @punctuation.delimiter
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+(type_arguments
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+"#;


### PR DESCRIPTION
# feat(highlight): Add Swift syntax highlighting

## Summary

Adds tree-sitter-based syntax highlighting for Swift files (`.swift`), following the same pattern as the C/C++ implementation (#155).

---

## Changes

### Files Modified

| File | Purpose |
|------|---------|
| `Cargo.toml` | Added `tree-sitter-swift = "=0.7.0"` dependency |
| `src/command/diff/highlight/queries.rs` | Hand-curated Swift highlighting rules |
| `src/command/diff/highlight/config.rs` | Registered Swift extension |
| `src/command/diff/highlight/mod.rs` | Added comprehensive tests |

### Key Features Supported

- **Comments**: Single-line and multi-line
- **Strings**: Regular, raw, escaped characters, interpolation `\(...)`
- **Numbers**: Integer, hex, octal, binary, floating-point
- **Literals**: `nil`, booleans (`true`/`false`), wildcards
- **Types**: Identifiers, built-in types, navigation expressions
- **Functions & Methods**: Declarations, calls, constructors (`init`)
- **Parameters**: Named and externally-named parameters
- **Self/Super**: Builtin variable highlighting
- **Attributes**: Swift attributes with `@` syntax
- **Keywords**: Full coverage including visibility modifiers, control flow, operators
- **Labels**: Statement labels for `break`/`continue` targets
- **Punctuation**: Delimiters and brackets

---

## Technical Details

### Dependency Pinning

```toml
tree-sitter-swift = "=0.7.0"
```

**Why exact version?** Version 0.7.1+ uses ABI v15, which conflicts with the project's `tree-sitter = "0.24"` (ABI v14). A caret requirement would silently resolve to 0.7.3 and cause runtime failures.

### Query Mapping

The upstream `highlights.scm` uses capture names that lumen doesn't support. This implementation provides a hand-curated query remapped to lumen's existing `HIGHLIGHT_NAMES` capture set.

**Note**: Node names and string tokens were verified against the 0.7.0 grammar's `node-types.json`. Special handling required for anonymous tokens (e.g., `throw`/`catch`/`else` are named nodes and captured via their node types instead).

---

## Testing

### Unit Tests

```bash
cargo test swift_highlighting
# Result: ✅ PASS
```

Test coverage includes:
- Keywords (`protocol`, `struct`, `func`, `var`, `let`, `init`, etc.)
- Type identifiers (protocols, structs, built-in types)
- Function declarations vs. method calls (tie-break logic verified)
- Constructor calls and `init` keyword
- Parameters, self/members, strings, numbers

### Full Test Suite

```bash
cargo test
# Result: 135/136 pass ✅
# Note: 1 pre-existing failure in vcs::git (unrelated to this PR)
```

### Code Quality

```bash
cargo clippy --all-targets
# Result: No new warnings in highlight module ✅
```

### Manual Verification

Ran `lumen diff` end-to-end against a Swift diff file containing:
- Protocol and struct declarations
- `init` constructor
- Method calls
- String interpolation

**Result**: Distinct colors verified for keywords, types, functions, strings, and numbers.

---

## Verification Checklist

- [x] `cargo build` — clean compilation
- [x] `cargo test` — all new tests pass
- [x] `cargo clippy --all-targets` — no new warnings
- [x] End-to-end manual testing with `lumen diff`
- [x] Follows existing C/C++ implementation pattern (#155)

---

**Related**: #155 (C/C++ syntax highlighting)

Closes #133 